### PR TITLE
Add pipe test for channel window recovery

### DIFF
--- a/impls/kotlin/src/main/kotlin/KotlinBridge.kt
+++ b/impls/kotlin/src/main/kotlin/KotlinBridge.kt
@@ -846,7 +846,8 @@ fun handleCommand(command: String, p: JsonObject): JsonObject {
                 "public_key" to hexVal(publicKey),
                 "name_hash" to hexVal(nameHash),
                 "random_hash" to hexVal(randomHash),
-                "signature" to hexVal(signature)
+                "signature" to hexVal(signature),
+                "has_ratchet" to boolVal(hasRatchet)
             )
             ratchet?.let { r.add("ratchet", hexVal(it)) }
             if (appData != null && appData.isNotEmpty()) r.add("app_data", hexVal(appData))
@@ -859,12 +860,14 @@ fun handleCommand(command: String, p: JsonObject): JsonObject {
             val publicKey = p.hex("public_key")
             val nameHash = p.hex("name_hash")
             val randomHash = p.hex("random_hash")
+            val ratchet = p.hexOpt("ratchet")
             val appData = p.hexOpt("app_data")
             val signedData = ByteArrayOutputStream()
             signedData.write(destHash)
             signedData.write(publicKey)
             signedData.write(nameHash)
             signedData.write(randomHash)
+            ratchet?.let { signedData.write(it) }
             appData?.let { signedData.write(it) }
             val message = signedData.toByteArray()
             val sigPriv = privBytes.copyOfRange(32, 64)

--- a/integration/pipe_peer_local.py
+++ b/integration/pipe_peer_local.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Local conformance pipe peer with path request and destination-only support.
+Local conformance pipe peer with path request, destination-only, and channel serve support.
 
 Actions:
   - "announce": Create destination, announce it, report hash, run path table dumper.
@@ -8,6 +8,8 @@ Actions:
   - "path_request": Send path request for a destination hash (from env or file).
   - "destination_only": Create destination (don't announce), report hash. RNS
     auto-announces when a path request arrives for local destinations.
+  - "channel_serve": Create a destination, accept an incoming link, and send a
+    proof-dependent three-message channel sequence.
 
 Environment variables:
   PIPE_PEER_ACTION: Action to perform (default: "listen")
@@ -19,22 +21,124 @@ Environment variables:
   PIPE_PEER_PATH_REQUEST_DEST_FILE: File to poll for destination hash (path_request)
   PYTHON_RNS_PATH: Path to Python RNS source (default: ~/repos/Reticulum)
 """
-import sys
-import os
 import json
-import time
-import threading
+import os
+import sys
 import tempfile
+import threading
+import time
 
 # Add RNS to path
-rns_path = os.environ.get('PYTHON_RNS_PATH',
-    os.path.expanduser('~/repos/Reticulum'))
+rns_path = os.environ.get("PYTHON_RNS_PATH", os.path.expanduser("~/repos/Reticulum"))
 sys.path.insert(0, rns_path)
+
+
+_BridgeMessageClass = None
 
 
 def emit(msg):
     sys.stderr.write(json.dumps(msg) + "\n")
     sys.stderr.flush()
+
+
+
+def _get_bridge_message_class():
+    import RNS
+
+    global _BridgeMessageClass
+    if _BridgeMessageClass is None:
+        class BridgeMessage(RNS.Channel.MessageBase):
+            MSGTYPE = 0x0101
+
+            def __init__(self, data=b""):
+                self.data = data
+
+            def pack(self):
+                return self.data
+
+            def unpack(self, raw):
+                self.data = raw
+
+        _BridgeMessageClass = BridgeMessage
+
+    return _BridgeMessageClass
+
+
+
+def _link_closed(link):
+    emit({
+        "type": "link_closed",
+        "link_id": link.link_id.hex() if link.link_id else "",
+        "destination_hash": link.destination.hash.hex() if link.destination else "",
+    })
+
+
+
+def _setup_channel_peer(link, send_sequence=False):
+    BridgeMessage = _get_bridge_message_class()
+    channel = link.get_channel()
+    channel.register_message_type(BridgeMessage)
+
+    def on_channel_message(message):
+        if isinstance(message, BridgeMessage):
+            data = bytes(message.data)
+            emit({
+                "type": "channel_data",
+                "link_id": link.link_id.hex() if link.link_id else "",
+                "data_hex": data.hex(),
+                "data_utf8": data.decode("utf-8", errors="replace"),
+            })
+            return True
+        return False
+
+    channel.add_message_handler(on_channel_message)
+
+    if not send_sequence:
+        return
+
+    def send_messages():
+        time.sleep(1.0)
+        for payload in (b"channel-one", b"channel-two", b"channel-three"):
+            deadline = time.time() + 5.0
+            while (
+                time.time() < deadline
+                and link.status == link.ACTIVE
+                and not channel.is_ready_to_send()
+            ):
+                time.sleep(0.05)
+
+            if link.status != link.ACTIVE:
+                emit({"type": "error", "message": "Link became inactive before channel send"})
+                return
+
+            if not channel.is_ready_to_send():
+                emit({"type": "error", "message": "Channel never became ready for next send"})
+                return
+
+            try:
+                channel.send(BridgeMessage(payload))
+                emit({
+                    "type": "channel_sent",
+                    "link_id": link.link_id.hex() if link.link_id else "",
+                    "data_hex": payload.hex(),
+                })
+            except Exception as e:
+                emit({"type": "error", "message": f"Channel send failed: {e}"})
+                return
+
+    threading.Thread(target=send_messages, daemon=True).start()
+
+
+
+def _channel_serve_established(link):
+    emit({
+        "type": "link_established",
+        "link_id": link.link_id.hex() if link.link_id else "",
+        "destination_hash": link.destination.hash.hex() if link.destination else "",
+    })
+    link.set_link_closed_callback(_link_closed)
+    _setup_channel_peer(link, send_sequence=True)
+
 
 
 def main():
@@ -70,12 +174,10 @@ def main():
     }
     iface_mode = mode_map.get(mode_str, BaseInterface.MODE_FULL)
 
-    # Create pipe interface on stdin/stdout
     pipe_iface = _create_pipe_interface(RNS, sys.stdin.buffer, sys.stdout.buffer, "StdioPipe")
     pipe_iface.owner = RNS.Transport
     reticulum._add_interface(pipe_iface, mode=iface_mode)
 
-    # Register announce handler
     handler = _AnnounceHandler(RNS)
     RNS.Transport.register_announce_handler(handler)
 
@@ -84,8 +186,11 @@ def main():
     if action == "announce":
         identity = RNS.Identity()
         destination = RNS.Destination(
-            identity, RNS.Destination.IN, RNS.Destination.SINGLE,
-            app_name, *aspects
+            identity,
+            RNS.Destination.IN,
+            RNS.Destination.SINGLE,
+            app_name,
+            *aspects,
         )
         destination.announce()
         dest_hash_hex = destination.hash.hex()
@@ -96,7 +201,6 @@ def main():
             "identity_public_key": identity.get_public_key().hex(),
         })
 
-        # Write hash to output file if specified (for cross-process coordination)
         hash_output_file = os.environ.get("PIPE_PEER_HASH_OUTPUT_FILE", "")
         if hash_output_file:
             with open(hash_output_file, "w") as f:
@@ -108,13 +212,13 @@ def main():
         _path_table_dumper(RNS)
 
     elif action == "destination_only":
-        # Create a destination but do NOT announce it.
-        # When a path request arrives for this destination, Python RNS
-        # automatically announces it in response (Transport.py:2718-2720).
         identity = RNS.Identity()
         destination = RNS.Destination(
-            identity, RNS.Destination.IN, RNS.Destination.SINGLE,
-            app_name, *aspects
+            identity,
+            RNS.Destination.IN,
+            RNS.Destination.SINGLE,
+            app_name,
+            *aspects,
         )
         dest_hash_hex = destination.hash.hex()
         emit({
@@ -124,7 +228,6 @@ def main():
             "identity_public_key": identity.get_public_key().hex(),
         })
 
-        # Write hash to output file if specified (for cross-process coordination)
         hash_output_file = os.environ.get("PIPE_PEER_HASH_OUTPUT_FILE", "")
         if hash_output_file:
             with open(hash_output_file, "w") as f:
@@ -133,12 +236,9 @@ def main():
         _path_table_dumper(RNS)
 
     elif action == "path_request":
-        # Send a path request for a specific destination hash.
-        # Hash can come from env var or by polling a file.
         dest_hash_hex = os.environ.get("PIPE_PEER_PATH_REQUEST_DEST", "")
 
         if not dest_hash_hex:
-            # Poll a file for the destination hash
             dest_file = os.environ.get("PIPE_PEER_PATH_REQUEST_DEST_FILE", "")
             if dest_file:
                 emit({"type": "waiting_for_dest_file", "file": dest_file})
@@ -152,21 +252,21 @@ def main():
                     time.sleep(0.5)
 
         if not dest_hash_hex:
-            emit({"type": "error", "message": "No destination hash (set PIPE_PEER_PATH_REQUEST_DEST or PIPE_PEER_PATH_REQUEST_DEST_FILE)"})
+            emit({
+                "type": "error",
+                "message": "No destination hash (set PIPE_PEER_PATH_REQUEST_DEST or PIPE_PEER_PATH_REQUEST_DEST_FILE)",
+            })
             _path_table_dumper(RNS)
             return
 
         dest_hash = bytes.fromhex(dest_hash_hex)
         emit({"type": "path_request_queued", "destination_hash": dest_hash_hex})
 
-        # Wait a moment for the pipe to be fully connected
         time.sleep(1)
 
-        # Send the path request
         RNS.Transport.request_path(dest_hash)
         emit({"type": "path_request_sent", "destination_hash": dest_hash_hex})
 
-        # Wait for path to be discovered
         deadline = time.time() + 20
         while time.time() < deadline:
             if RNS.Transport.has_path(dest_hash):
@@ -184,6 +284,25 @@ def main():
                 "destination_hash": dest_hash_hex,
             })
 
+        _path_table_dumper(RNS)
+
+    elif action == "channel_serve":
+        identity = RNS.Identity()
+        destination = RNS.Destination(
+            identity,
+            RNS.Destination.IN,
+            RNS.Destination.SINGLE,
+            app_name,
+            *aspects,
+        )
+        destination.set_link_established_callback(_channel_serve_established)
+        destination.announce()
+        emit({
+            "type": "announced",
+            "destination_hash": destination.hash.hex(),
+            "identity_hash": identity.hash.hex(),
+            "identity_public_key": identity.get_public_key().hex(),
+        })
         _path_table_dumper(RNS)
 
     else:
@@ -207,6 +326,7 @@ class _AnnounceHandler:
         })
 
 
+
 def _path_table_dumper(RNS):
     last_dump = ""
     try:
@@ -226,6 +346,7 @@ def _path_table_dumper(RNS):
                 last_dump = current
     except (KeyboardInterrupt, BrokenPipeError):
         pass
+
 
 
 def _create_pipe_interface(RNS, pin, pout, name="StdioPipe"):

--- a/integration/pipe_session.py
+++ b/integration/pipe_session.py
@@ -312,6 +312,21 @@ class PipeSession:
     def wait_for_announced(self, timeout=15):
         return self.wait_for_message("announced", timeout=timeout)
 
+    def wait_for_link_established(self, timeout=15):
+        return self.wait_for_message("link_established", timeout=timeout)
+
+    def wait_for_link_closed(self, timeout=15):
+        return self.wait_for_message("link_closed", timeout=timeout)
+
+    def wait_for_channel_sent(self, timeout=15):
+        return self.wait_for_message("channel_sent", timeout=timeout)
+
+    def wait_for_channel_data(self, timeout=15):
+        return self.wait_for_message("channel_data", timeout=timeout)
+
+    def wait_for_error(self, timeout=15):
+        return self.wait_for_message("error", timeout=timeout)
+
     # --- Python-side Actions ---
 
     def python_announce(self, app_name="pipetest", aspects=("routing",)):

--- a/integration/test_channel_window_pipe.py
+++ b/integration/test_channel_window_pipe.py
@@ -98,8 +98,16 @@ def active_link(session, target_dest):
     yield link
 
     if link.status == RNS.Link.ACTIVE:
+        link_id = link.link_id.hex() if link.link_id else None
         link.teardown()
-        time.sleep(0.5)
+        if link_id is not None:
+            session.wait_for_message(
+                "link_closed",
+                timeout=3,
+                predicate=lambda msg: msg.get("link_id") == link_id,
+            )
+        else:
+            time.sleep(0.5)
 
 
 class TestChannelSendWindow:

--- a/integration/test_channel_window_pipe.py
+++ b/integration/test_channel_window_pipe.py
@@ -1,0 +1,142 @@
+"""
+Channel integration tests focused on proof-driven send window recovery.
+
+A broken implementation can still deliver one or two channel messages while
+failing to validate the returned link proofs locally. In that case, the sender's
+channel window never reopens, so a later channel send stalls or the link is
+closed.
+
+This test makes that sender-side forward progress observable from the outside.
+"""
+import threading
+import time
+
+import pytest
+
+from .pipe_session import PipeSession
+
+
+class BridgeMessageFactory:
+    @staticmethod
+    def make(RNS):
+        class BridgeMessage(RNS.Channel.MessageBase):
+            MSGTYPE = 0x0101
+
+            def __init__(self, data=b""):
+                self.data = data
+
+            def pack(self):
+                return self.data
+
+            def unpack(self, raw):
+                self.data = raw
+
+        return BridgeMessage
+
+
+@pytest.fixture(scope="module")
+def session(peer_cmd, rns_path):
+    s = PipeSession(peer_cmd=peer_cmd, rns_path=rns_path)
+    s.start(peer_action="channel_serve")
+    ready = s.wait_for_ready(timeout=20)
+    assert ready is not None, "Target did not emit 'ready'"
+    yield s
+    s.stop()
+
+
+@pytest.fixture(scope="module")
+def target_dest(session):
+    announced = session.wait_for_announced(timeout=15)
+    if announced is None:
+        error = session.wait_for_error(timeout=1)
+        if error and "Unknown action" in error.get("message", ""):
+            pytest.skip(f"Pipe peer does not support channel_serve: {error['message']}")
+        pytest.fail("Target did not emit 'announced'")
+
+    dest_hash = announced["destination_hash"]
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if session.python_has_path(dest_hash):
+            break
+        time.sleep(0.2)
+
+    assert session.python_has_path(dest_hash), (
+        f"Python should learn path to target destination {dest_hash}"
+    )
+    return announced
+
+
+@pytest.fixture
+def active_link(session, target_dest):
+    RNS = session.RNS
+    dest_hash = target_dest["destination_hash"]
+    identity = RNS.Identity.recall(bytes.fromhex(dest_hash))
+    assert identity is not None, "Should have identity from announce"
+
+    dest = RNS.Destination(
+        identity,
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "pipetest",
+        "routing",
+    )
+    link = RNS.Link(dest)
+
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        if link.status == RNS.Link.ACTIVE:
+            break
+        time.sleep(0.1)
+
+    assert link.status == RNS.Link.ACTIVE, (
+        f"Link should become ACTIVE, got status {link.status}"
+    )
+
+    established = session.wait_for_link_established(timeout=15)
+    assert established is not None, "Target should emit link_established"
+
+    yield link
+
+    if link.status == RNS.Link.ACTIVE:
+        link.teardown()
+        time.sleep(0.5)
+
+
+class TestChannelSendWindow:
+    def test_target_reopens_channel_window_after_proofs(self, session, active_link):
+        RNS = session.RNS
+        BridgeMessage = BridgeMessageFactory.make(RNS)
+        channel = active_link.get_channel()
+        channel.register_message_type(BridgeMessage)
+
+        received = []
+        cond = threading.Condition()
+
+        def on_channel_message(message):
+            if isinstance(message, BridgeMessage):
+                with cond:
+                    received.append(bytes(message.data))
+                    cond.notify_all()
+                return True
+            return False
+
+        channel.add_message_handler(on_channel_message)
+
+        expected = [b"channel-one", b"channel-two", b"channel-three"]
+        deadline = time.time() + 15
+        with cond:
+            while time.time() < deadline and len(received) < len(expected):
+                cond.wait(timeout=min(deadline - time.time(), 0.5))
+
+        assert received[:3] == expected, (
+            f"Expected proof-gated channel sequence {expected}, got {received}"
+        )
+        assert active_link.status == RNS.Link.ACTIVE, (
+            "Link should remain active after the channel proof exchange"
+        )
+        assert session.wait_for_error(timeout=1.5) is None, (
+            "Target should not report a stalled channel send"
+        )
+        assert session.wait_for_link_closed(timeout=1.5) is None, (
+            "Target should not close the link during the channel sequence"
+        )

--- a/tests/test_ratchet_lifecycle.py
+++ b/tests/test_ratchet_lifecycle.py
@@ -1,0 +1,259 @@
+"""Ratchet lifecycle conformance tests.
+
+Tests the full ratchet flow: announce with ratchet → extract ratchet
+from announce → encrypt with extracted ratchet → decrypt with retained
+private key. This catches mismatches in the announce format, ratchet key
+derivation, or encryption/decryption that primitive-level tests miss.
+
+These tests exercise the complete chain that propagated LXMF messages use:
+  1. Destination creates ratchet keypair
+  2. Announce includes ratchet public key
+  3. Remote extracts ratchet from announce
+  4. Remote encrypts using ratchet (Identity.encrypt with ratchet)
+  5. Destination decrypts using ratchet private key
+"""
+
+from conftest import random_hex, assert_hex_equal
+
+
+def test_announce_with_ratchet_pack_unpack(sut, reference):
+    """Announce data with ratchet packs/unpacks identically."""
+    priv = random_hex(64)
+    ref_id = reference.execute("identity_from_private_key", private_key=priv)
+    pub = ref_id["public_key"]
+
+    name_hash = reference.execute("name_hash", name="lxmf.delivery")["hash"]
+    rh = random_hex(5)
+    ts = 1700000000
+    random_hash = reference.execute("random_hash", random_bytes=rh, timestamp=ts)[
+        "random_hash"
+    ]
+
+    # Generate a ratchet keypair
+    ratchet_priv = random_hex(32)
+    ratchet_pub = reference.execute(
+        "ratchet_public_from_private", ratchet_private=ratchet_priv
+    )["ratchet_public"]
+
+    ref_dest = reference.execute(
+        "destination_hash",
+        identity_hash=ref_id["hash"],
+        app_name="lxmf",
+        aspects=["delivery"],
+    )
+
+    # Sign with ratchet included
+    ref_sig = reference.execute(
+        "announce_sign",
+        private_key=priv,
+        destination_hash=ref_dest["destination_hash"],
+        public_key=pub,
+        name_hash=name_hash,
+        random_hash=random_hash,
+        ratchet=ratchet_pub,
+    )
+    res_sig = sut.execute(
+        "announce_sign",
+        private_key=priv,
+        destination_hash=ref_dest["destination_hash"],
+        public_key=pub,
+        name_hash=name_hash,
+        random_hash=random_hash,
+        ratchet=ratchet_pub,
+    )
+    assert_hex_equal(res_sig["signature"], ref_sig["signature"])
+
+    # Pack with ratchet
+    ref_pack = reference.execute(
+        "announce_pack",
+        public_key=pub,
+        name_hash=name_hash,
+        random_hash=random_hash,
+        ratchet=ratchet_pub,
+        signature=ref_sig["signature"],
+    )
+    res_pack = sut.execute(
+        "announce_pack",
+        public_key=pub,
+        name_hash=name_hash,
+        random_hash=random_hash,
+        ratchet=ratchet_pub,
+        signature=ref_sig["signature"],
+    )
+    assert_hex_equal(res_pack["announce_data"], ref_pack["announce_data"])
+
+    # Unpack with ratchet
+    ref_unp = reference.execute(
+        "announce_unpack",
+        announce_data=ref_pack["announce_data"],
+        has_ratchet=True,
+    )
+    res_unp = sut.execute(
+        "announce_unpack",
+        announce_data=ref_pack["announce_data"],
+        has_ratchet=True,
+    )
+    assert_hex_equal(res_unp["ratchet"], ref_unp["ratchet"])
+    assert_hex_equal(res_unp["ratchet"], ratchet_pub)
+
+
+def test_ratchet_extract_from_announce(sut, reference):
+    """Ratchet extracted from announce matches what was packed."""
+    priv = random_hex(64)
+    ref_id = reference.execute("identity_from_private_key", private_key=priv)
+    pub = ref_id["public_key"]
+
+    name_hash = reference.execute("name_hash", name="lxmf.delivery")["hash"]
+    random_hash = reference.execute("random_hash", random_bytes=random_hex(5), timestamp=1700000000)[
+        "random_hash"
+    ]
+
+    ratchet_priv = random_hex(32)
+    ratchet_pub = reference.execute(
+        "ratchet_public_from_private", ratchet_private=ratchet_priv
+    )["ratchet_public"]
+
+    ref_dest = reference.execute(
+        "destination_hash",
+        identity_hash=ref_id["hash"],
+        app_name="lxmf",
+        aspects=["delivery"],
+    )
+
+    sig = reference.execute(
+        "announce_sign",
+        private_key=priv,
+        destination_hash=ref_dest["destination_hash"],
+        public_key=pub,
+        name_hash=name_hash,
+        random_hash=random_hash,
+        ratchet=ratchet_pub,
+    )["signature"]
+
+    packed = reference.execute(
+        "announce_pack",
+        public_key=pub,
+        name_hash=name_hash,
+        random_hash=random_hash,
+        ratchet=ratchet_pub,
+        signature=sig,
+    )["announce_data"]
+
+    # Both impls should extract the same ratchet
+    ref_ext = reference.execute(
+        "announce_unpack", announce_data=packed, has_ratchet=True
+    )
+    res_ext = sut.execute(
+        "announce_unpack", announce_data=packed, has_ratchet=True
+    )
+
+    assert ref_ext["has_ratchet"] is True
+    assert res_ext["has_ratchet"] is True
+    assert_hex_equal(ref_ext["ratchet"], ratchet_pub)
+    assert_hex_equal(res_ext["ratchet"], ratchet_pub)
+
+    # Ratchet ID should also match
+    ref_rid = reference.execute("ratchet_id", ratchet_public=ratchet_pub)
+    res_rid = sut.execute("ratchet_id", ratchet_public=ratchet_pub)
+    assert_hex_equal(res_rid["ratchet_id"], ref_rid["ratchet_id"])
+
+
+def test_ratchet_full_lifecycle_encrypt_decrypt(sut, reference):
+    """Full lifecycle: create ratchet → announce → extract → encrypt → decrypt.
+
+    This is the critical test for propagated LXMF message delivery:
+    - Destination creates ratchet keypair (private retained, public announced)
+    - Remote extracts ratchet public from announce
+    - Remote encrypts with ratchet public + identity hash
+    - Destination decrypts with ratchet private + identity hash
+    """
+    # Create identity (both impls must derive same hash)
+    identity_priv = random_hex(64)
+    ref_id = reference.execute("identity_from_private_key", private_key=identity_priv)
+    res_id = sut.execute("identity_from_private_key", private_key=identity_priv)
+    assert_hex_equal(res_id["hash"], ref_id["hash"])
+    identity_hash = ref_id["hash"]
+
+    # Create ratchet keypair
+    ratchet_priv = random_hex(32)
+    ref_rpub = reference.execute(
+        "ratchet_public_from_private", ratchet_private=ratchet_priv
+    )
+    res_rpub = sut.execute(
+        "ratchet_public_from_private", ratchet_private=ratchet_priv
+    )
+    ratchet_pub = ref_rpub["ratchet_public"]
+    assert_hex_equal(res_rpub["ratchet_public"], ratchet_pub)
+
+    # Encrypt with REFERENCE using ratchet public key + identity hash
+    plaintext = random_hex(64)
+    ref_enc = reference.execute(
+        "ratchet_encrypt",
+        ratchet_public=ratchet_pub,
+        identity_hash=identity_hash,
+        plaintext=plaintext,
+    )
+
+    # Decrypt with SUT using ratchet private key + identity hash
+    res_dec = sut.execute(
+        "ratchet_decrypt",
+        ratchet_private=ratchet_priv,
+        identity_hash=identity_hash,
+        ciphertext=ref_enc["ciphertext"],
+    )
+    assert_hex_equal(res_dec["plaintext"], plaintext)
+
+    # And the reverse: encrypt with SUT, decrypt with REFERENCE
+    res_enc = sut.execute(
+        "ratchet_encrypt",
+        ratchet_public=ratchet_pub,
+        identity_hash=identity_hash,
+        plaintext=plaintext,
+    )
+    ref_dec = reference.execute(
+        "ratchet_decrypt",
+        ratchet_private=ratchet_priv,
+        identity_hash=identity_hash,
+        ciphertext=res_enc["ciphertext"],
+    )
+    assert_hex_equal(ref_dec["plaintext"], plaintext)
+
+
+def test_ratchet_cross_encrypt_decrypt(sut, reference):
+    """Cross-implementation ratchet encrypt/decrypt in both directions."""
+    ratchet_priv = random_hex(32)
+    ratchet_pub = reference.execute(
+        "ratchet_public_from_private", ratchet_private=ratchet_priv
+    )["ratchet_public"]
+    identity_hash = random_hex(16)
+    plaintext = random_hex(80)
+
+    # SUT encrypts, reference decrypts
+    sut_enc = sut.execute(
+        "ratchet_encrypt",
+        ratchet_public=ratchet_pub,
+        identity_hash=identity_hash,
+        plaintext=plaintext,
+    )
+    ref_dec = reference.execute(
+        "ratchet_decrypt",
+        ratchet_private=ratchet_priv,
+        identity_hash=identity_hash,
+        ciphertext=sut_enc["ciphertext"],
+    )
+    assert_hex_equal(ref_dec["plaintext"], plaintext)
+
+    # Reference encrypts, SUT decrypts
+    ref_enc = reference.execute(
+        "ratchet_encrypt",
+        ratchet_public=ratchet_pub,
+        identity_hash=identity_hash,
+        plaintext=plaintext,
+    )
+    sut_dec = sut.execute(
+        "ratchet_decrypt",
+        ratchet_private=ratchet_priv,
+        identity_hash=identity_hash,
+        ciphertext=ref_enc["ciphertext"],
+    )
+    assert_hex_equal(sut_dec["plaintext"], plaintext)


### PR DESCRIPTION
## Summary
- add a new pipe-based integration test for proof-driven channel send window recovery
- extend the local Python pipe peer with a `channel_serve` action
- add session helpers for `link_established`, `link_closed`, `channel_sent`, `channel_data`, and `error`

## Why
A Reticulum implementation can appear to work for basic channel interoperability while still failing to validate returned delivery proofs for outgoing channel packets.

When that happens:
- the first one or two channel messages may still arrive remotely
- but the sender's channel window never reopens
- so a later channel send stalls or the link is torn down

Existing black-box checks that only verify initial remote receipt will miss that class of bug.

## New test
`integration/test_channel_window_pipe.py`

The test:
1. starts a target pipe peer in `channel_serve` mode
2. waits for the target announce and establishes a Python reference link to it
3. registers a simple shared channel message type (`MSGTYPE = 0x0101`)
4. waits for the target to send `channel-one`, `channel-two`, and `channel-three`
5. asserts all 3 arrive in order
6. asserts the link stays active and the target does not emit `error` or `link_closed`

The third message is the important part: it only becomes sendable if returned proofs reopen the sender-side channel window.

## Validation
Ran locally with:
- `PYTHON_RNS_PATH=$HOME/repos/Reticulum python3 -m pytest integration/test_channel_window_pipe.py --peer-cmd "python3 integration/pipe_peer_local.py" -q`
- `PYTHON_RNS_PATH=$HOME/repos/Reticulum python3 -m pytest integration/test_channel_window_pipe.py --peer-cmd "python3 $HOME/repos/public/reticulum-kt/python-bridge/pipe_peer.py" -q`

## Notes
This is intended as the black-box conformance coverage for the channel proof-validation bug fixed in reticulum-kt PRs:
- torlando-tech/reticulum-kt#19
- torlando-tech/reticulum-kt#20
