### PR TITLE
Add DEFAULT_IFAC_SIZE to _StdioPipe

### DIFF
--- a/integration/pipe_session.py
+++ b/integration/pipe_session.py
@@ -163,6 +163,7 @@ class PipeSession:
         process = self.process
 
         class _StdioPipe(BaseInterface):
+            DEFAULT_IFAC_SIZE = 8
             FLAG = 0x7E
             ESC = 0x7D
             ESC_MASK = 0x20


### PR DESCRIPTION
## Summary
- Adds `DEFAULT_IFAC_SIZE = 8` to the `_StdioPipe` inner class in `pipe_session.py` so it matches every other `BaseInterface` subclass in upstream Reticulum.

## Why
Upstream `Reticulum._add_interface` reads `interface.DEFAULT_IFAC_SIZE` as the fallback when no `ifac_size` is configured (`RNS/Reticulum.py:963`). Without this class attribute, test setup raises `AttributeError: '_StdioPipe' object has no attribute 'DEFAULT_IFAC_SIZE'` before the pipe can be added to the Reticulum instance, failing every pytest run in this repo (observed on reticulum-kt PR #25).

## Test plan
- [x] Integration tests using `pipe_session.py` proceed past `_add_interface`
- [ ] Downstream: `torlando-tech/reticulum-kt` conformance job passes once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)