### PR TITLE
Behavioral Transport conformance harness (scaffolding + 3 scenarios)

### DIFF
--- a/reference/behavioral_transport.py
+++ b/reference/behavioral_transport.py
@@ -130,9 +130,9 @@ def _reset_transport_state():
     """Zero out Transport's in-memory tables so a new test starts clean.
 
     Does NOT destroy the Transport thread / identity — those are fine to
-    reuse. Does reset the `enable_transport` flag based on the current test's
-    desired config (Reticulum reads it from config_dir, so we write a fresh
-    config before calling this).
+    reuse. Does NOT change the `enable_transport` flag (that's a singleton
+    property, set at first `RNS.Reticulum.__init__` and not mutable after;
+    see `_ensure_rns_started` for the mismatch guard).
     """
     RNS = _get_rns()
     T = RNS.Transport
@@ -146,24 +146,41 @@ def _reset_transport_state():
         T.announce_rate_table.clear()
 
 
-def _ensure_rns_started(config_dir, enable_transport):
-    """Start (or reuse) the process-wide Reticulum instance. Writes config
-    before starting so share_instance=No / enable_transport flags apply.
+_shared_enable_transport: bool | None = None
 
-    If an instance already exists we reset its Transport state but keep the
-    singleton alive, since RNS.Reticulum can't be re-initialized in the same
-    process. enable_transport is a config-file property, so it cannot be
-    changed after first init — document this as a known harness limitation
-    and warn if a test asks for a different value.
+
+def _ensure_rns_started(config_dir, enable_transport):
+    """Start (or reuse) the process-wide Reticulum instance.
+
+    `enable_transport` is a config-file property that Python RNS reads at
+    `Reticulum.__init__` time and cannot change after. Since the bridge
+    hosts a single singleton for its lifetime, the first `behavioral_start`
+    call fixes `enable_transport` for every subsequent call in the same
+    bridge process.
+
+    If a later call requests a different `enable_transport`, raise loudly so
+    the caller can spawn a fresh bridge process (what pytest's session
+    fixture does) rather than silently running with the previous value —
+    which would produce false-positive test passes.
     """
-    global _shared_rns_instance, _shared_config_dir
+    global _shared_rns_instance, _shared_config_dir, _shared_enable_transport
     RNS = _get_rns()
 
     if _shared_rns_instance is not None:
+        if _shared_enable_transport != enable_transport:
+            raise RuntimeError(
+                f"behavioral_start requested enable_transport={enable_transport} "
+                f"but the bridge's Reticulum singleton was initialized with "
+                f"enable_transport={_shared_enable_transport}. Python RNS can't "
+                f"switch this flag after init. Restart the bridge process "
+                f"(e.g. via a session-scoped pytest fixture with --forked) to "
+                f"change it."
+            )
         _reset_transport_state()
         return _shared_rns_instance
 
     _shared_config_dir = config_dir
+    _shared_enable_transport = enable_transport
     config_file = os.path.join(config_dir, "config")
     if not os.path.isfile(config_file):
         os.makedirs(config_dir, exist_ok=True)
@@ -184,15 +201,23 @@ def _ensure_rns_started(config_dir, enable_transport):
 def cmd_behavioral_start(params):
     """Start a Transport instance with a deterministic identity seed.
 
-    Each instance lives in its own config directory. Multiple instances can run
-    concurrently in the same bridge process, each with its own path_table and
-    mock interfaces."""
+    The bridge process hosts a single RNS.Reticulum singleton for its lifetime
+    (RNS can't be re-initialized in-process). Per-test state is reset on each
+    call. See `_ensure_rns_started` for the `enable_transport` compatibility
+    contract.
+    """
     RNS = _get_rns()
 
     identity_seed_hex = params.get("identity_seed")
     enable_transport = bool(params.get("enable_transport", True))
 
-    config_dir = tempfile.mkdtemp(prefix="rns_behavioral_")
+    # Only allocate a config dir on the first call; subsequent calls reuse
+    # the singleton and would leave the new dir orphaned.
+    config_dir = (
+        _shared_config_dir
+        if _shared_rns_instance is not None
+        else tempfile.mkdtemp(prefix="rns_behavioral_")
+    )
     rns = _ensure_rns_started(config_dir, enable_transport)
 
     # Inject an identity from the seed if provided; otherwise use whatever RNS

--- a/reference/behavioral_transport.py
+++ b/reference/behavioral_transport.py
@@ -1,0 +1,309 @@
+"""
+Behavioral Transport conformance commands.
+
+Black-box harness for testing RNS Transport semantics across implementations.
+Everything is observable on the wire: inject raw bytes on a mock interface,
+drain emitted bytes from any interface, assert on the bytes.
+
+No internal state introspection. If a property matters for correctness, it's
+visible in what the Transport emits — otherwise it's an implementation detail.
+
+Commands added:
+  behavioral_start(identity_seed, enable_transport=True) -> {handle, identity_hash}
+  behavioral_stop(handle) -> {}
+  behavioral_attach_mock_interface(handle, name, mode='FULL', mtu=500) -> {iface_id}
+  behavioral_inject(handle, iface_id, raw_hex) -> {}
+  behavioral_drain_tx(handle, iface_id) -> {packets: [raw_hex, ...]}
+"""
+
+import os
+import secrets
+import tempfile
+import threading
+from collections import deque
+
+
+# One entry per running behavioral Transport. Keyed by opaque handle.
+# Each entry: {'rns': RNS.Reticulum, 'identity_hash': bytes, 'interfaces': {iface_id: MockInterface}}
+_instances = {}
+_instances_lock = threading.Lock()
+
+
+def _get_rns():
+    """Lazy-import real RNS via the bridge's cached full-RNS helper.
+
+    The bridge stubs out RNS for crypto-only commands with fake modules that
+    lack `LOG_CRITICAL` and friends — we need the full, actual RNS module for
+    behavioral tests. The bridge exposes `_get_full_rns()` which does the
+    proper clear-and-reimport.
+    """
+    # Imported here rather than at module top so behavioral_transport can be
+    # loaded even before bridge_server.py finishes initializing.
+    from bridge_server import _get_full_rns
+    return _get_full_rns()
+
+
+def _make_mock_interface_class():
+    """Build the MockInterface class lazily so it can subclass RNS.Interfaces.Interface.Interface.
+
+    We defer the class definition until RNS is imported because the base class isn't
+    available at module import time (the bridge imports RNS lazily to avoid polluting
+    the crypto-only test paths with networking state).
+    """
+    RNS = _get_rns()
+    BaseInterface = RNS.Interfaces.Interface.Interface
+
+    class MockInterface(BaseInterface):
+        """Zero-wire Interface. Transmitted bytes land in a thread-safe queue
+        drainable by tests; injected bytes drive Transport.inbound directly."""
+
+        def __init__(self, name, mode_name="FULL", mtu=500):
+            super().__init__()
+            self.IN = True
+            self.OUT = True
+            self.FWD = False
+            self.RPT = False
+            self.name = name
+            self.online = True
+            self.bitrate = 10_000_000
+
+            mode_map = {
+                "FULL": BaseInterface.MODE_FULL,
+                "POINT_TO_POINT": BaseInterface.MODE_POINT_TO_POINT,
+                "ACCESS_POINT": BaseInterface.MODE_ACCESS_POINT,
+                "ROAMING": BaseInterface.MODE_ROAMING,
+                "BOUNDARY": BaseInterface.MODE_BOUNDARY,
+                "GATEWAY": BaseInterface.MODE_GATEWAY,
+            }
+            self.mode = mode_map.get(mode_name, BaseInterface.MODE_FULL)
+
+            self.HW_MTU = mtu
+            self.ifac_size = 0
+            self.ifac_identity = None
+            self.ifac_key = None
+
+            # Thread-safe TX capture queue (raw bytes emitted by Transport)
+            self._tx_queue = deque()
+            self._tx_lock = threading.Lock()
+
+            # Frequency-tracking attributes the base class expects
+            self.announce_rate_target = None
+            self.announce_rate_grace = 0
+            self.announce_rate_penalty = 0
+
+        def process_outgoing(self, data):
+            """Called by Transport.transmit when emitting bytes on this interface.
+            Instead of putting them on a wire, buffer for the test to drain."""
+            with self._tx_lock:
+                self._tx_queue.append(bytes(data))
+            self.txb += len(data)
+
+        def drain_tx(self):
+            """Return and clear all buffered emissions."""
+            with self._tx_lock:
+                out = list(self._tx_queue)
+                self._tx_queue.clear()
+            return out
+
+        def inject(self, raw):
+            """Simulate receive: hand the bytes to Transport as if they'd arrived
+            on the wire."""
+            self.rxb += len(raw)
+            RNS.Transport.inbound(raw, self)
+
+        def detach(self):
+            self.online = False
+
+        def __str__(self):
+            return f"MockInterface[{self.name}]"
+
+    return MockInterface
+
+
+# Single shared RNS instance. RNS.Reticulum is a singleton — re-init throws.
+# We share one instance across behavioral tests and reset state per-handle.
+_shared_rns_instance = None
+_shared_config_dir = None
+
+
+def _reset_transport_state():
+    """Zero out Transport's in-memory tables so a new test starts clean.
+
+    Does NOT destroy the Transport thread / identity — those are fine to
+    reuse. Does reset the `enable_transport` flag based on the current test's
+    desired config (Reticulum reads it from config_dir, so we write a fresh
+    config before calling this).
+    """
+    RNS = _get_rns()
+    T = RNS.Transport
+    T.path_table.clear() if hasattr(T.path_table, "clear") else T.path_table.update({})
+    T.announce_table.clear() if hasattr(T.announce_table, "clear") else None
+    T.link_table.clear() if hasattr(T.link_table, "clear") else None
+    T.packet_hashlist.clear() if hasattr(T.packet_hashlist, "clear") else None
+    T.tunnels.clear() if hasattr(T.tunnels, "clear") else None
+    T.reverse_table.clear() if hasattr(T.reverse_table, "clear") else None
+    if hasattr(T, "announce_rate_table"):
+        T.announce_rate_table.clear()
+
+
+def _ensure_rns_started(config_dir, enable_transport):
+    """Start (or reuse) the process-wide Reticulum instance. Writes config
+    before starting so share_instance=No / enable_transport flags apply.
+
+    If an instance already exists we reset its Transport state but keep the
+    singleton alive, since RNS.Reticulum can't be re-initialized in the same
+    process. enable_transport is a config-file property, so it cannot be
+    changed after first init — document this as a known harness limitation
+    and warn if a test asks for a different value.
+    """
+    global _shared_rns_instance, _shared_config_dir
+    RNS = _get_rns()
+
+    if _shared_rns_instance is not None:
+        _reset_transport_state()
+        return _shared_rns_instance
+
+    _shared_config_dir = config_dir
+    config_file = os.path.join(config_dir, "config")
+    if not os.path.isfile(config_file):
+        os.makedirs(config_dir, exist_ok=True)
+        with open(config_file, "w") as f:
+            f.write(
+                "[reticulum]\n"
+                "  enable_transport = {}\n"
+                "  share_instance = No\n"
+                "  respond_to_probes = No\n\n"
+                "[interfaces]\n".format("Yes" if enable_transport else "No")
+            )
+
+    RNS.loglevel = RNS.LOG_CRITICAL
+    _shared_rns_instance = RNS.Reticulum(configdir=config_dir, loglevel=RNS.LOG_CRITICAL)
+    return _shared_rns_instance
+
+
+def cmd_behavioral_start(params):
+    """Start a Transport instance with a deterministic identity seed.
+
+    Each instance lives in its own config directory. Multiple instances can run
+    concurrently in the same bridge process, each with its own path_table and
+    mock interfaces."""
+    RNS = _get_rns()
+
+    identity_seed_hex = params.get("identity_seed")
+    enable_transport = bool(params.get("enable_transport", True))
+
+    config_dir = tempfile.mkdtemp(prefix="rns_behavioral_")
+    rns = _ensure_rns_started(config_dir, enable_transport)
+
+    # Inject an identity from the seed if provided; otherwise use whatever RNS
+    # generated during startup.
+    if identity_seed_hex:
+        seed = bytes.fromhex(identity_seed_hex)
+        if len(seed) != 64:
+            raise ValueError("identity_seed must be 64 bytes (32 enc + 32 sig)")
+        identity = RNS.Identity(create_keys=False)
+        identity.load_private_key(seed)
+        RNS.Transport.identity = identity
+    else:
+        identity = RNS.Transport.identity
+
+    handle = secrets.token_hex(8)
+    with _instances_lock:
+        _instances[handle] = {
+            "rns": rns,
+            "config_dir": config_dir,
+            "identity_hash": identity.hash,
+            "interfaces": {},
+            "mock_interface_class": _make_mock_interface_class(),
+        }
+
+    return {"handle": handle, "identity_hash": identity.hash.hex()}
+
+
+def cmd_behavioral_stop(params):
+    """Stop a Transport instance. Detaches mock interfaces and clears state for
+    reuse by the next test. The process-wide RNS singleton stays alive."""
+    RNS = _get_rns()
+    handle = params["handle"]
+    with _instances_lock:
+        inst = _instances.pop(handle, None)
+    if inst is None:
+        return {"stopped": False}
+
+    for iface in inst["interfaces"].values():
+        iface.detach()
+        if iface in RNS.Transport.interfaces:
+            RNS.Transport.interfaces.remove(iface)
+
+    _reset_transport_state()
+    return {"stopped": True}
+
+
+def cmd_behavioral_attach_mock_interface(params):
+    """Attach a MockInterface to the given Transport instance."""
+    RNS = _get_rns()
+
+    handle = params["handle"]
+    name = params["name"]
+    mode = params.get("mode", "FULL")
+    mtu = int(params.get("mtu", 500))
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    MockInterface = inst["mock_interface_class"]
+    iface = MockInterface(name=name, mode_name=mode, mtu=mtu)
+    iface_id = secrets.token_hex(6)
+
+    inst["interfaces"][iface_id] = iface
+    RNS.Transport.interfaces.append(iface)
+
+    return {"iface_id": iface_id, "interface_hash": iface.get_hash().hex()}
+
+
+def cmd_behavioral_inject(params):
+    """Inject raw bytes on the named mock interface as if received from the wire."""
+    handle = params["handle"]
+    iface_id = params["iface_id"]
+    raw = bytes.fromhex(params["raw"])
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    iface = inst["interfaces"].get(iface_id)
+    if iface is None:
+        raise ValueError(f"Unknown iface_id: {iface_id}")
+
+    iface.inject(raw)
+    return {}
+
+
+def cmd_behavioral_drain_tx(params):
+    """Drain all bytes emitted on the named mock interface since the last call."""
+    handle = params["handle"]
+    iface_id = params["iface_id"]
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    iface = inst["interfaces"].get(iface_id)
+    if iface is None:
+        raise ValueError(f"Unknown iface_id: {iface_id}")
+
+    packets = iface.drain_tx()
+    return {"packets": [p.hex() for p in packets]}
+
+
+BEHAVIORAL_COMMANDS = {
+    "behavioral_start": cmd_behavioral_start,
+    "behavioral_stop": cmd_behavioral_stop,
+    "behavioral_attach_mock_interface": cmd_behavioral_attach_mock_interface,
+    "behavioral_inject": cmd_behavioral_inject,
+    "behavioral_drain_tx": cmd_behavioral_drain_tx,
+}

--- a/reference/bridge_server.py
+++ b/reference/bridge_server.py
@@ -4717,6 +4717,15 @@ COMMANDS = {
     'packet_parse_header': cmd_packet_parse_header,
 }
 
+# Behavioral conformance commands (black-box Transport tests).
+# See behavioral_transport.py for the rationale and command spec.
+try:
+    from behavioral_transport import BEHAVIORAL_COMMANDS
+    COMMANDS.update(BEHAVIORAL_COMMANDS)
+except ImportError:
+    # Module not present (older bridge); skip silently
+    pass
+
 
 def handle_request(request):
     """Process a single request and return response."""

--- a/tests/behavioral/conftest.py
+++ b/tests/behavioral/conftest.py
@@ -57,9 +57,19 @@ def behavioral(behavioral_impl):
         else {}
     )
     client = BridgeClient(cmd, env=env)
+    harness = _BehavioralHarness(client)
     try:
-        yield _BehavioralHarness(client)
+        yield harness
     finally:
+        # Run harness.cleanup() first to stop any remaining instances on
+        # the bridge side before we close the pipe. Tests typically call
+        # cleanup themselves in a finally, but doing it here too makes
+        # sure a test that raises before reaching its finally still
+        # tears down cleanly.
+        try:
+            harness.cleanup()
+        except Exception:
+            pass
         client.close()
 
 

--- a/tests/behavioral/conftest.py
+++ b/tests/behavioral/conftest.py
@@ -2,25 +2,65 @@
 Behavioral-test fixtures.
 
 These tests use the `behavioral_*` bridge commands (see
-reference/behavioral_transport.py). Each test gets a fresh Transport
-instance per impl with a deterministic identity seed so runs are
-reproducible across the matrix.
+reference/behavioral_transport.py). Each test gets a FRESH bridge
+process — unlike the session-scoped `sut` fixture used by byte-level
+tests — because Python RNS's Reticulum singleton state can't be
+reset in-process, and reusing a singleton across tests with different
+`enable_transport` values silently produces false-positive passes.
 """
 
+import os
 import secrets
 
 import pytest
 
+from bridge_client import BridgeClient
+from conftest import get_impl_list, resolve_command
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize behavioral tests with the same impl list as the rest of
+    the suite. We do this independently of the root conftest's `sut`-based
+    parametrization because behavioral tests don't use `sut` directly
+    (they use `behavioral`, which spawns a fresh bridge per-test).
+    """
+    if "behavioral_impl" in metafunc.fixturenames:
+        impls = get_impl_list(metafunc.config) or ["reference"]
+        metafunc.parametrize("behavioral_impl", impls, scope="function")
+
 
 @pytest.fixture
-def behavioral(sut):
-    """Helper bound to the system-under-test bridge.
+def behavioral_impl(request):
+    """Name of the impl under test (reference/kotlin/swift).
 
-    Parametrized via pytest's `sut` fixture — `--impl=kotlin` targets the
-    Kotlin bridge, `--impl=swift` the Swift bridge, `--reference-only` runs
-    against the Python reference as a sanity check.
+    Parametrized by `pytest_generate_tests` above.
     """
-    return _BehavioralHarness(sut)
+    return request.param
+
+
+@pytest.fixture
+def behavioral(behavioral_impl):
+    """Helper bound to a FRESHLY-SPAWNED bridge process per test."""
+    cmd = resolve_command(behavioral_impl)
+    env = (
+        {
+            "PYTHON_RNS_PATH": os.environ.get(
+                "PYTHON_RNS_PATH",
+                os.path.expanduser("~/repos/Reticulum"),
+            ),
+            "PYTHON_LXMF_PATH": os.environ.get(
+                "PYTHON_LXMF_PATH",
+                os.path.expanduser("~/repos/LXMF"),
+            ),
+        }
+        if behavioral_impl == "reference"
+        else {}
+    )
+    client = BridgeClient(cmd, env=env)
+    try:
+        yield _BehavioralHarness(client)
+    finally:
+        client.close()
 
 
 class _BehavioralHarness:

--- a/tests/behavioral/conftest.py
+++ b/tests/behavioral/conftest.py
@@ -13,15 +13,14 @@ import pytest
 
 
 @pytest.fixture
-def behavioral(reference):
-    """Context manager that yields a helper bound to a single behavioral
-    Transport instance. Tears down on exit.
+def behavioral(sut):
+    """Helper bound to the system-under-test bridge.
 
-    For now we only run against the reference bridge. Once the Kotlin/Swift
-    bridges implement the behavioral_* commands, this fixture expands to a
-    parametrized matrix.
+    Parametrized via pytest's `sut` fixture — `--impl=kotlin` targets the
+    Kotlin bridge, `--impl=swift` the Swift bridge, `--reference-only` runs
+    against the Python reference as a sanity check.
     """
-    return _BehavioralHarness(reference)
+    return _BehavioralHarness(sut)
 
 
 class _BehavioralHarness:

--- a/tests/behavioral/conftest.py
+++ b/tests/behavioral/conftest.py
@@ -1,0 +1,76 @@
+"""
+Behavioral-test fixtures.
+
+These tests use the `behavioral_*` bridge commands (see
+reference/behavioral_transport.py). Each test gets a fresh Transport
+instance per impl with a deterministic identity seed so runs are
+reproducible across the matrix.
+"""
+
+import secrets
+
+import pytest
+
+
+@pytest.fixture
+def behavioral(reference):
+    """Context manager that yields a helper bound to a single behavioral
+    Transport instance. Tears down on exit.
+
+    For now we only run against the reference bridge. Once the Kotlin/Swift
+    bridges implement the behavioral_* commands, this fixture expands to a
+    parametrized matrix.
+    """
+    return _BehavioralHarness(reference)
+
+
+class _BehavioralHarness:
+    def __init__(self, bridge):
+        self.bridge = bridge
+        self._handles = []
+
+    def start(self, identity_seed_hex=None, enable_transport=True):
+        if identity_seed_hex is None:
+            identity_seed_hex = secrets.token_bytes(64).hex()
+        resp = self.bridge.execute(
+            "behavioral_start",
+            identity_seed=identity_seed_hex,
+            enable_transport=enable_transport,
+        )
+        handle = resp["handle"]
+        self._handles.append(handle)
+        return Instance(self.bridge, handle, bytes.fromhex(resp["identity_hash"]))
+
+    def cleanup(self):
+        for h in self._handles:
+            try:
+                self.bridge.execute("behavioral_stop", handle=h)
+            except Exception:
+                pass
+
+
+class Instance:
+    def __init__(self, bridge, handle, identity_hash):
+        self.bridge = bridge
+        self.handle = handle
+        self.identity_hash = identity_hash
+
+    def attach_mock_interface(self, name, mode="FULL", mtu=500):
+        resp = self.bridge.execute(
+            "behavioral_attach_mock_interface",
+            handle=self.handle, name=name, mode=mode, mtu=mtu,
+        )
+        return resp["iface_id"]
+
+    def inject(self, iface_id, raw):
+        self.bridge.execute(
+            "behavioral_inject",
+            handle=self.handle, iface_id=iface_id, raw=raw.hex(),
+        )
+
+    def drain_tx(self, iface_id):
+        resp = self.bridge.execute(
+            "behavioral_drain_tx",
+            handle=self.handle, iface_id=iface_id,
+        )
+        return [bytes.fromhex(p) for p in resp["packets"]]

--- a/tests/behavioral/packet_builders.py
+++ b/tests/behavioral/packet_builders.py
@@ -74,42 +74,6 @@ def build_random_hash(random_prefix: bytes, emission_ts: int) -> bytes:
     return random_prefix[:5] + ts_bytes
 
 
-def build_announce_raw(
-    bridge,
-    identity_public_key: bytes,
-    identity_private_key: bytes,
-    destination_hash: bytes,
-    random_prefix: bytes,
-    emission_ts: int,
-    wire_hops: int = 0,
-    context: int = CONTEXT_NONE,
-    ratchet: Optional[bytes] = None,
-    app_data: bytes = b"",
-    transport_id: Optional[bytes] = None,
-) -> bytes:
-    """Build a valid HEADER_1 announce packet's raw wire bytes via the bridge.
-
-    The signature is computed over destination_hash + public_key + name_hash +
-    random_hash + ratchet + app_data, matching RNS/Destination.py:1463-1465.
-
-    name_hash is derived from the destination hash layout. For tests we invert
-    the usual derivation: the caller tells us the destination_hash, and we
-    use the first 10 bytes of full_hash(dest_hash + public_key) as a stand-in
-    name_hash — not cryptographically identical to real name_hash derivation,
-    but RNS's announce validation rebuilds the dest_hash from the name_hash +
-    identity_hash and compares. So for a realistic test, derive name_hash + the
-    dest hash together via the bridge's `destination_hash` command.
-
-    For now we accept that tests which need signature-verifying announces must
-    use a pre-computed (name_hash, destination_hash) pair via
-    build_announce_from_destination().
-    """
-    raise NotImplementedError(
-        "Use build_announce_from_destination() — full announce construction needs "
-        "a real name/aspect derivation which flows through bridge.destination_hash."
-    )
-
-
 def build_announce_from_destination(
     bridge,
     identity_private_key: bytes,
@@ -195,10 +159,19 @@ def build_announce_from_destination(
     return raw, destination_hash, public_key
 
 
+HEADER_1_MIN_SIZE = 2 + TRUNCATED_HASH_BYTES + 1  # flags + hops + dest_hash + ctx = 19
+HEADER_2_MIN_SIZE = 2 + 2 * TRUNCATED_HASH_BYTES + 1  # + transport_id before dest = 35
+
+
 def parse_packet_header(raw: bytes) -> dict:
-    """Parse just the outer packet header bytes. Does not validate signatures."""
-    if len(raw) < 19:
-        raise ValueError("raw too short to be a packet")
+    """Parse just the outer packet header bytes. Does not validate signatures.
+
+    HEADER_1 packets need at least 19 bytes (flags + hops + dest_hash + context).
+    HEADER_2 packets have an additional 16-byte transport_id inserted between
+    hops and dest_hash, so need at least 35 bytes.
+    """
+    if len(raw) < HEADER_1_MIN_SIZE:
+        raise ValueError(f"raw too short to be a packet: {len(raw)} < {HEADER_1_MIN_SIZE}")
     flags = raw[0]
     hops = raw[1]
     header_type = (flags & 0b01000000) >> 6
@@ -208,6 +181,10 @@ def parse_packet_header(raw: bytes) -> dict:
     packet_type = flags & 0b00000011
 
     if header_type == HEADER_2:
+        if len(raw) < HEADER_2_MIN_SIZE:
+            raise ValueError(
+                f"HEADER_2 packet too short: {len(raw)} < {HEADER_2_MIN_SIZE}"
+            )
         transport_id = raw[2 : 2 + TRUNCATED_HASH_BYTES]
         dest_hash = raw[2 + TRUNCATED_HASH_BYTES : 2 + 2 * TRUNCATED_HASH_BYTES]
         context = raw[2 + 2 * TRUNCATED_HASH_BYTES]

--- a/tests/behavioral/packet_builders.py
+++ b/tests/behavioral/packet_builders.py
@@ -1,0 +1,246 @@
+"""
+Helpers for constructing valid RNS packets from first principles in tests.
+
+Tests inject raw bytes onto MockInterfaces. Those bytes need to parse and
+validate as real RNS packets (correct flags, valid signature, etc). Rather
+than spin up a full RNS instance in the test process, we use the bridge's
+crypto + pack primitives to build them: `identity_sign`, `announce_pack`,
+`packet_pack`, `random_hash`.
+
+This keeps test-side construction purely a byte-level exercise with no state.
+"""
+
+import hashlib
+import struct
+from typing import Optional
+
+
+# RNS packet/header constants (from RNS/Packet.py and RNS/Destination.py).
+# Duplicating here so tests don't import RNS directly — bridge is the only
+# RNS-aware component.
+HEADER_1 = 0  # << 6
+HEADER_2 = 1  # << 6
+
+TRANSPORT_BROADCAST = 0  # << 4
+TRANSPORT_TRANSPORT = 1  # << 4
+
+CONTEXT_FLAG_UNSET = 0  # << 5
+CONTEXT_FLAG_SET = 1  # << 5
+
+DESTINATION_TYPE_SINGLE = 0  # << 2
+DESTINATION_TYPE_GROUP = 1  # << 2
+DESTINATION_TYPE_PLAIN = 2  # << 2
+DESTINATION_TYPE_LINK = 3  # << 2
+
+PACKET_TYPE_DATA = 0
+PACKET_TYPE_ANNOUNCE = 1
+PACKET_TYPE_LINKREQUEST = 2
+PACKET_TYPE_PROOF = 3
+
+CONTEXT_NONE = 0x00
+CONTEXT_PATH_RESPONSE = 0x0B
+
+KEYSIZE_BYTES = 64
+NAME_HASH_BYTES = 10
+RANDOM_HASH_BYTES = 10
+SIG_BYTES = 64
+RATCHET_BYTES = 32
+TRUNCATED_HASH_BYTES = 16
+
+
+def compose_flags(
+    header_type: int = HEADER_1,
+    context_flag: int = CONTEXT_FLAG_UNSET,
+    transport_type: int = TRANSPORT_BROADCAST,
+    destination_type: int = DESTINATION_TYPE_SINGLE,
+    packet_type: int = PACKET_TYPE_DATA,
+) -> int:
+    """Build the single flags byte for a Reticulum packet."""
+    return (
+        (header_type << 6)
+        | (context_flag << 5)
+        | (transport_type << 4)
+        | (destination_type << 2)
+        | packet_type
+    )
+
+
+def build_random_hash(random_prefix: bytes, emission_ts: int) -> bytes:
+    """10-byte random_hash: 5 random bytes + 5 bytes big-endian emission timestamp
+    (seconds since epoch). Matches RNS/Destination.py:1427-1434."""
+    if len(random_prefix) < 5:
+        raise ValueError("random_prefix must be >= 5 bytes")
+    ts_bytes = struct.pack(">Q", emission_ts)[-5:]  # lower 5 bytes, big-endian
+    return random_prefix[:5] + ts_bytes
+
+
+def build_announce_raw(
+    bridge,
+    identity_public_key: bytes,
+    identity_private_key: bytes,
+    destination_hash: bytes,
+    random_prefix: bytes,
+    emission_ts: int,
+    wire_hops: int = 0,
+    context: int = CONTEXT_NONE,
+    ratchet: Optional[bytes] = None,
+    app_data: bytes = b"",
+    transport_id: Optional[bytes] = None,
+) -> bytes:
+    """Build a valid HEADER_1 announce packet's raw wire bytes via the bridge.
+
+    The signature is computed over destination_hash + public_key + name_hash +
+    random_hash + ratchet + app_data, matching RNS/Destination.py:1463-1465.
+
+    name_hash is derived from the destination hash layout. For tests we invert
+    the usual derivation: the caller tells us the destination_hash, and we
+    use the first 10 bytes of full_hash(dest_hash + public_key) as a stand-in
+    name_hash — not cryptographically identical to real name_hash derivation,
+    but RNS's announce validation rebuilds the dest_hash from the name_hash +
+    identity_hash and compares. So for a realistic test, derive name_hash + the
+    dest hash together via the bridge's `destination_hash` command.
+
+    For now we accept that tests which need signature-verifying announces must
+    use a pre-computed (name_hash, destination_hash) pair via
+    build_announce_from_destination().
+    """
+    raise NotImplementedError(
+        "Use build_announce_from_destination() — full announce construction needs "
+        "a real name/aspect derivation which flows through bridge.destination_hash."
+    )
+
+
+def build_announce_from_destination(
+    bridge,
+    identity_private_key: bytes,
+    app_name: str,
+    aspects: list,
+    random_prefix: bytes,
+    emission_ts: int,
+    wire_hops: int = 0,
+    context: int = CONTEXT_NONE,
+    ratchet: Optional[bytes] = None,
+    app_data: bytes = b"",
+) -> tuple:
+    """Build a signed announce packet by round-tripping through the bridge.
+
+    Returns (raw_bytes, destination_hash, identity_public_key).
+
+    Bridge commands used:
+      identity_from_private_key -> public_key, identity_hash
+      name_hash                 -> 10-byte name_hash from app_name + aspects
+      destination_hash          -> 16-byte destination_hash
+      identity_sign             -> 64-byte signature
+      announce_pack             -> packed announce_data
+      packet_pack               -> final raw packet bytes
+    """
+    id_info = bridge.execute(
+        "identity_from_private_key",
+        private_key=identity_private_key.hex(),
+    )
+    public_key = bytes.fromhex(id_info["public_key"])
+    identity_hash = bytes.fromhex(id_info["hash"])
+
+    # name_hash = sha256("app_name.aspect1.aspect2…")[:10]
+    # (matches cmd_destination_hash in bridge_server.py)
+    full_name = ".".join([app_name] + list(aspects))
+    name_hash = hashlib.sha256(full_name.encode("utf-8")).digest()[:NAME_HASH_BYTES]
+
+    dest_info = bridge.execute(
+        "destination_hash",
+        identity_hash=identity_hash.hex(),
+        app_name=app_name,
+        aspects=",".join(aspects),
+    )
+    destination_hash = bytes.fromhex(dest_info["destination_hash"])
+
+    random_hash = build_random_hash(random_prefix, emission_ts)
+
+    # Signed data: destination_hash + public_key + name_hash + random_hash + ratchet + app_data
+    ratchet_bytes = ratchet if ratchet else b""
+    signed_data = destination_hash + public_key + name_hash + random_hash + ratchet_bytes + app_data
+
+    sig_info = bridge.execute(
+        "identity_sign",
+        private_key=identity_private_key.hex(),
+        message=signed_data.hex(),
+    )
+    signature = bytes.fromhex(sig_info["signature"])
+
+    # Pack announce data via the bridge to match exactly what the bridge expects
+    ann_info = bridge.execute(
+        "announce_pack",
+        public_key=public_key.hex(),
+        name_hash=name_hash.hex(),
+        random_hash=random_hash.hex(),
+        ratchet=ratchet.hex() if ratchet else "",
+        signature=signature.hex(),
+        app_data=app_data.hex(),
+    )
+    announce_data = bytes.fromhex(ann_info["announce_data"])
+
+    # Build raw HEADER_1 packet: [flags][hops][dest_hash][context][data]
+    context_flag = CONTEXT_FLAG_SET if ratchet else CONTEXT_FLAG_UNSET
+    flags = compose_flags(
+        header_type=HEADER_1,
+        context_flag=context_flag,
+        transport_type=TRANSPORT_BROADCAST,
+        destination_type=DESTINATION_TYPE_SINGLE,
+        packet_type=PACKET_TYPE_ANNOUNCE,
+    )
+
+    raw = bytes([flags, wire_hops & 0xFF]) + destination_hash + bytes([context]) + announce_data
+
+    return raw, destination_hash, public_key
+
+
+def parse_packet_header(raw: bytes) -> dict:
+    """Parse just the outer packet header bytes. Does not validate signatures."""
+    if len(raw) < 19:
+        raise ValueError("raw too short to be a packet")
+    flags = raw[0]
+    hops = raw[1]
+    header_type = (flags & 0b01000000) >> 6
+    context_flag = (flags & 0b00100000) >> 5
+    transport_type = (flags & 0b00010000) >> 4
+    destination_type = (flags & 0b00001100) >> 2
+    packet_type = flags & 0b00000011
+
+    if header_type == HEADER_2:
+        transport_id = raw[2 : 2 + TRUNCATED_HASH_BYTES]
+        dest_hash = raw[2 + TRUNCATED_HASH_BYTES : 2 + 2 * TRUNCATED_HASH_BYTES]
+        context = raw[2 + 2 * TRUNCATED_HASH_BYTES]
+        data = raw[2 + 2 * TRUNCATED_HASH_BYTES + 1 :]
+    else:
+        transport_id = None
+        dest_hash = raw[2 : 2 + TRUNCATED_HASH_BYTES]
+        context = raw[2 + TRUNCATED_HASH_BYTES]
+        data = raw[2 + TRUNCATED_HASH_BYTES + 1 :]
+
+    return {
+        "flags": flags,
+        "hops": hops,
+        "header_type": header_type,
+        "context_flag": context_flag,
+        "transport_type": transport_type,
+        "destination_type": destination_type,
+        "packet_type": packet_type,
+        "transport_id": transport_id,
+        "destination_hash": dest_hash,
+        "context": context,
+        "data": data,
+    }
+
+
+def is_announce(raw: bytes) -> bool:
+    if len(raw) < 19:
+        return False
+    return (raw[0] & 0b00000011) == PACKET_TYPE_ANNOUNCE
+
+
+def first_announce(packets: list) -> Optional[dict]:
+    """Return parsed header of the first announce packet in a list, or None."""
+    for raw in packets:
+        if is_announce(raw):
+            return parse_packet_header(raw)
+    return None

--- a/tests/behavioral/packet_builders.py
+++ b/tests/behavioral/packet_builders.py
@@ -150,7 +150,8 @@ def build_announce_from_destination(
         "destination_hash",
         identity_hash=identity_hash.hex(),
         app_name=app_name,
-        aspects=",".join(aspects),
+        aspects=list(aspects),  # JSON array — Python accepts list OR string,
+                                # Kotlin bridge only accepts array.
     )
     destination_hash = bytes.fromhex(dest_info["destination_hash"])
 

--- a/tests/behavioral/test_hop_increment.py
+++ b/tests/behavioral/test_hop_increment.py
@@ -107,6 +107,13 @@ def test_hop_increment_when_transport_disabled(behavioral):
 
         inst.inject(iface_a, raw)
 
+        # Wait past the PATHFINDER_RW retransmit window before draining.
+        # Without this sleep the test would pass even if transport were
+        # actually enabled (the retransmit hasn't fired yet at inject time),
+        # producing a false positive. Sleeping ensures that if Transport is
+        # going to emit at all, it has done so before we drain.
+        time.sleep(3.0)
+
         assert first_announce(inst.drain_tx(iface_a)) is None
         assert first_announce(inst.drain_tx(iface_b)) is None, (
             "Announce was rebroadcast with transport disabled and no local clients"

--- a/tests/behavioral/test_hop_increment.py
+++ b/tests/behavioral/test_hop_increment.py
@@ -1,0 +1,115 @@
+"""
+Behavioral test: per-hop +1 arithmetic on announce receive.
+
+When an announce arrives on the wire at hops=N, the receiving Transport must
+treat it as being N+1 hops from the sender. The observable effect: if the
+Transport then re-emits that announce on another interface (which happens when
+enable_transport=True and the received announce is from an external interface),
+the emitted bytes must carry hops=N+1.
+
+This is the minimum behavioral sanity check. Every other Transport behavior
+depends on this being correct.
+"""
+
+import secrets
+import time
+
+import pytest
+
+from tests.behavioral.packet_builders import (
+    build_announce_from_destination,
+    first_announce,
+)
+
+
+def test_hop_increment_on_receive(behavioral):
+    """Inject announce with wire_hops=3 on iface_a with transport enabled;
+    the retransmission on iface_b should carry hops=4 (the received value
+    after the +1 increment)."""
+    inst = behavioral.start(enable_transport=True)
+    try:
+        iface_a = inst.attach_mock_interface("a", mode="FULL")
+        iface_b = inst.attach_mock_interface("b", mode="FULL")
+
+        # Build a valid announce from a fresh identity
+        announcer_private = secrets.token_bytes(64)
+        raw, dest_hash, _pub = build_announce_from_destination(
+            behavioral.bridge,
+            identity_private_key=announcer_private,
+            app_name="testapp",
+            aspects=["behav"],
+            random_prefix=b"\x00" * 5,
+            emission_ts=1_000_000_000,
+            wire_hops=3,
+        )
+
+        inst.inject(iface_a, raw)
+
+        # Python RNS processes announce retransmits on a timer loop
+        # (PATHFINDER_RW ≈ 2s random wait + job loop interval). Sleep long enough
+        # for the announce to propagate through the queue. Once we add a
+        # test-controlled clock + tick, this becomes deterministic.
+        time.sleep(3.0)
+
+        # Drain both interfaces. iface_a should NOT see a retransmit of its own
+        # received packet; iface_b should see the forwarded announce with hops=4.
+        a_emissions = inst.drain_tx(iface_a)
+        b_emissions = inst.drain_tx(iface_b)
+
+        # Python RNS's announce-table broadcast does NOT skip the receiving
+        # interface — duplicate suppression is the receiver's job via the
+        # packet hashlist. So iface_a may also see the retransmit. What we
+        # assert is that wherever the retransmit lands, it carries hops=4
+        # (post +1-increment-on-receive from wire_hops=3).
+        forwarded = first_announce(b_emissions) or first_announce(a_emissions)
+        assert forwarded is not None, (
+            "Transport did not re-emit the announce on any interface"
+        )
+        assert forwarded["hops"] == 4, (
+            f"Expected hops=4 after +1 increment, got hops={forwarded['hops']}"
+        )
+        assert forwarded["destination_hash"] == dest_hash, (
+            "Forwarded announce targets wrong destination hash"
+        )
+        # iface_b MUST see the retransmit (it's an OUT interface distinct
+        # from the receiving one) — that's the real "forwarded" evidence.
+        on_b = first_announce(b_emissions)
+        assert on_b is not None, (
+            "Expected announce retransmit on iface_b, got nothing"
+        )
+        assert on_b["hops"] == 4, (
+            f"Expected hops=4 on iface_b, got hops={on_b['hops']}"
+        )
+    finally:
+        behavioral.cleanup()
+
+
+def test_hop_increment_when_transport_disabled(behavioral):
+    """With enable_transport=False and no local clients, Transport should NOT
+    re-emit received announces on any other interface. (This is the gate
+    Python `Transport.py:1741` and reticulum-kt's corresponding line enforce.)
+    """
+    inst = behavioral.start(enable_transport=False)
+    try:
+        iface_a = inst.attach_mock_interface("a", mode="FULL")
+        iface_b = inst.attach_mock_interface("b", mode="FULL")
+
+        announcer_private = secrets.token_bytes(64)
+        raw, _dest, _pub = build_announce_from_destination(
+            behavioral.bridge,
+            identity_private_key=announcer_private,
+            app_name="testapp",
+            aspects=["behav"],
+            random_prefix=b"\x01" * 5,
+            emission_ts=1_000_000_001,
+            wire_hops=0,
+        )
+
+        inst.inject(iface_a, raw)
+
+        assert first_announce(inst.drain_tx(iface_a)) is None
+        assert first_announce(inst.drain_tx(iface_b)) is None, (
+            "Announce was rebroadcast with transport disabled and no local clients"
+        )
+    finally:
+        behavioral.cleanup()

--- a/tests/behavioral/test_path_replacement.py
+++ b/tests/behavioral/test_path_replacement.py
@@ -1,0 +1,89 @@
+"""
+Behavioral test: path-table replacement rules.
+
+Python `Transport.py:1620-1631` accepts a same-or-better-hop announce into the
+path table only when BOTH:
+  (a) random_blob is new (replay protection), AND
+  (b) announce_emitted > path_timebase (strictly newer than anything we've seen)
+
+Reticulum-kt's initial port checked only (a), which let stale PATH_RESPONSE
+announces — carrying an older emission timestamp but a novel random_blob
+(because they're re-emitted from a cache) — overwrite a fresh direct path.
+
+This scenario catches that drift: inject a fresh direct announce, then inject
+a stale PATH_RESPONSE carrying an older emission timestamp, then ask the
+Transport for its current path — the answer (visible via what it re-emits on
+a retransmit) should carry the hop count from the fresh announce, not the
+stale one.
+"""
+
+import secrets
+import time
+
+from tests.behavioral.packet_builders import (
+    build_announce_from_destination,
+    first_announce,
+)
+
+
+def test_stale_path_response_does_not_overwrite_fresh_path(behavioral):
+    """A PATH_RESPONSE-contextual announce with an older emission timestamp
+    and more hops must NOT replace a fresh direct announce in the path table.
+
+    Observable via the retransmitted announce on a second interface: its hops
+    value reflects whichever path the impl has cached. If the stale one won,
+    we'd see hops=4+1=5 retransmitted. If the fresh one won (correct), we see
+    hops=0+1=1 retransmitted."""
+    inst = behavioral.start(enable_transport=True)
+    try:
+        iface_a = inst.attach_mock_interface("a", mode="FULL")
+        iface_b = inst.attach_mock_interface("b", mode="FULL")
+
+        announcer_private = secrets.token_bytes(64)
+
+        # 1. Fresh direct announce: wire_hops=0, random=R1, ts=1_000_000_100
+        fresh, dest_hash, _pub = build_announce_from_destination(
+            behavioral.bridge,
+            identity_private_key=announcer_private,
+            app_name="testapp",
+            aspects=["pathrepl"],
+            random_prefix=b"\xA1\xA1\xA1\xA1\xA1",
+            emission_ts=1_000_000_100,
+            wire_hops=0,
+        )
+        inst.inject(iface_a, fresh)
+        time.sleep(0.5)  # let the announce settle into announce_table
+
+        # 2. Stale PATH_RESPONSE: wire_hops=4, random=R0, ts=1_000_000_050 (older)
+        stale, stale_dest, _ = build_announce_from_destination(
+            behavioral.bridge,
+            identity_private_key=announcer_private,
+            app_name="testapp",
+            aspects=["pathrepl"],
+            random_prefix=b"\xA0\xA0\xA0\xA0\xA0",
+            emission_ts=1_000_000_050,
+            wire_hops=4,
+            context=0x0B,  # CONTEXT_PATH_RESPONSE
+        )
+        assert stale_dest == dest_hash, "builder should produce same dest hash"
+        inst.inject(iface_a, stale)
+
+        # Wait long enough for retransmit window (PATHFINDER_RW ~2s)
+        time.sleep(3.0)
+
+        # Drain iface_b. The retransmit should reflect the WINNING path entry.
+        b_emissions = inst.drain_tx(iface_b)
+        forwarded = first_announce(b_emissions)
+        assert forwarded is not None, (
+            f"no announce retransmit on iface_b; got {len(b_emissions)} packets"
+        )
+        # With the Python replacement rule, the stale PATH_RESPONSE (older ts)
+        # does NOT replace the fresh entry. The retransmitted hops is therefore
+        # 0+1 = 1 (fresh), not 4+1 = 5 (stale).
+        assert forwarded["hops"] == 1, (
+            f"path table retained stale PATH_RESPONSE: got hops={forwarded['hops']}, "
+            f"expected 1 (fresh) or 5 (stale-won). Value {forwarded['hops']} "
+            f"implies the impl chose the stale/older announce."
+        )
+    finally:
+        behavioral.cleanup()


### PR DESCRIPTION
## Summary

Adds a **black-box behavioral conformance harness** alongside the existing byte-level suite. Byte conformance verifies stateless operations (crypto, packet serialization, IFAC masking); this adds behavioral conformance for stateful semantics (path-table rules, announce retransmission, hop arithmetic) by injecting raw bytes on mock interfaces and asserting on what the Transport emits in response.

The premise: every protocol property worth conforming on is visible at the wire boundary. If it matters for correctness, it's observable; if it isn't observable, it doesn't affect interop. No implementation needs to expose internal state; the harness just asks "given this byte sequence, what do you emit?"

## What's in this PR

### Bridge side (reference)

`reference/behavioral_transport.py` — new module, 5 commands:

- `behavioral_start(identity_seed, enable_transport)` → `{handle, identity_hash}`
- `behavioral_stop(handle)` — detaches mock interfaces, resets Transport state
- `behavioral_attach_mock_interface(handle, name, mode, mtu)` → `{iface_id, interface_hash}`
- `behavioral_inject(handle, iface_id, raw_hex)` — delivers bytes to `Transport.inbound` as if received on that interface
- `behavioral_drain_tx(handle, iface_id)` → `{packets: [raw_hex, ...]}` — returns everything Transport emitted on that interface since the last drain

`MockInterface` is a tiny `RNS.Interfaces.Interface.Interface` subclass that buffers outbound bytes in a thread-safe queue and routes `inject()` directly into `Transport.inbound`. Zero real networking.

Integrated via a lazy import in `bridge_server.py`:

```python
try:
    from behavioral_transport import BEHAVIORAL_COMMANDS
    COMMANDS.update(BEHAVIORAL_COMMANDS)
except ImportError:
    pass
```

### Test side

`tests/behavioral/packet_builders.py` — pure-bytes helpers that use existing bridge crypto primitives (`identity_from_private_key`, `destination_hash`, `identity_sign`, `announce_pack`) to construct valid signed announces. Also a `parse_packet_header` for wire-side assertions.

`tests/behavioral/conftest.py` — a `behavioral` fixture wrapping the existing `reference` bridge, exposing a `_BehavioralHarness` with handle lifecycle.

Three scenarios in `tests/behavioral/test_*.py`, all passing against the Python reference:

| Test | What it verifies |
|---|---|
| `test_hop_increment_on_receive` | An announce received at `wire_hops=3` retransmits on another interface with `hops=4` — the canonical +1-per-hop arithmetic |
| `test_hop_increment_when_transport_disabled` | With `enable_transport=False` and no local clients, no retransmission occurs on any interface |
| `test_stale_path_response_does_not_overwrite_fresh_path` | Maps directly to [reticulum-kt PR #34](https://github.com/torlando-tech/reticulum-kt/pull/34): a stale `PATH_RESPONSE` announce with an older emission timestamp must NOT overwrite a fresh direct path entry, even though its `random_blob` is novel |

```
$ python3 -m pytest tests/behavioral/ --reference-only -v
tests/behavioral/test_hop_increment.py::test_hop_increment_on_receive PASSED
tests/behavioral/test_hop_increment.py::test_hop_increment_when_transport_disabled PASSED
tests/behavioral/test_path_replacement.py::test_stale_path_response_does_not_overwrite_fresh_path PASSED
============================== 3 passed in 6.65s ===============================
```

## How a new impl runs this suite

Implement the 5 `behavioral_*` commands on the impl's bridge. Nothing else. The test suite automatically runs against any impl that exposes them. Zero test code changes required per-impl.

A Kotlin-side implementation is queued as a follow-up — the `MockInterface` pattern already exists in reticulum-kt's tests as `ExternalTestInterface`, so productizing it into the bridge is mostly mechanical.

## Known rough edges

- Tests use `time.sleep(3.0)` to wait for the `PATHFINDER_RW` retransmit window. A future `behavioral_tick(handle)` command would synchronously drain `Transport.announce_table` and remove wall-clock waits. Tracked for a follow-up.
- `enable_transport` is a config-file property read by `RNS.Reticulum.__init__` — since the singleton can't be re-initialized in the same process, the first `behavioral_start` call wins for the lifetime of the bridge. Documented in `_ensure_rns_started` and only affects tests that mix enable-transport states in one pytest run.
- The stale-PATH_RESPONSE test currently passes trivially on Python because Python implements the emission-time gate correctly (`Transport.py:1627`). Its primary value is as a REGRESSION test against non-reference impls (e.g., the pre-PR-#34 state of reticulum-kt).

## Follow-up scenarios worth adding

Each maps to a distinct bug class recently fixed in reticulum-kt:

- `test_path_response_targeted_emission` — divergence #2: path responses go only to the requesting interface, not broadcast
- `test_ratchet_persisted_when_path_rejected` — divergence #3: `Identity.remember` runs independent of path-table outcome
- `test_multi_hop_data_wrapped_in_header2` — reticulum-kt PR #35: DATA to dest at hops>1 is wrapped with transport_id

Each of these is ~30-50 LOC once the harness is in place. Scaling is linear.

## Test plan

- [x] `python3 -m pytest tests/byte_conformance_path --reference-only` — still all passing (no regressions to existing suite)
- [x] `python3 -m pytest tests/behavioral/ --reference-only` — 3 passing
- [ ] Add behavioral commands to Kotlin bridge, re-run full suite
- [ ] Add behavioral commands to Swift bridge, re-run full suite