### PR TITLE
Add IFAC conformance tests (byte-level + wire E2E) for reticulum-kt#29

### DIFF
--- a/reference/bridge_server.py
+++ b/reference/bridge_server.py
@@ -4726,6 +4726,14 @@ except ImportError:
     # Module not present (older bridge); skip silently
     pass
 
+# Wire-level TCP interop commands (E2E IFAC tests).
+# See wire_tcp.py for the rationale and command spec.
+try:
+    from wire_tcp import WIRE_COMMANDS
+    COMMANDS.update(WIRE_COMMANDS)
+except ImportError:
+    pass
+
 
 def handle_request(request):
     """Process a single request and return response."""

--- a/reference/wire_tcp.py
+++ b/reference/wire_tcp.py
@@ -1,0 +1,323 @@
+"""Wire-level TCP conformance commands (E2E IFAC interop harness).
+
+Unlike behavioral_transport.py (MockInterface, zero-wire), this module spins
+up a *real* Reticulum instance with a real TCP interface. Two bridges — one
+server-role, one client-role — connect over loopback TCP with matching IFAC
+configuration. Announces on one side are only observable on the other if
+each side's IFAC bytes verify on the peer.
+
+Motivated by reticulum-kt#29: Kotlin's native IFAC produced wire bytes that
+Python's IFAC unmasker silently rejected. Byte-level primitive tests
+(see tests/test_ifac.py) cover HKDF + Ed25519 + mask algorithm equality.
+This module covers the layer above: full packet flow through a real RNS
+instance and real TCP framing, reproducing the issue-#29 symptom end-to-end.
+
+Commands:
+  wire_start_tcp_server(network_name, passphrase, bind_port=0)
+    -> {handle, port, identity_hash}
+  wire_start_tcp_client(network_name, passphrase, target_host, target_port)
+    -> {handle, identity_hash}
+  wire_announce(handle, app_name, aspects=[], app_data="")
+    -> {destination_hash, identity_hash}
+  wire_poll_path(handle, destination_hash, timeout_ms=5000)
+    -> {found: bool, hops: int | None}
+  wire_stop(handle) -> {stopped: bool}
+
+Each bridge process hosts at most one wire RNS singleton. Attempting a second
+wire_start on the same bridge raises — spawn a fresh bridge subprocess for
+the second peer. The pytest `wire_peers` fixture does exactly this.
+"""
+
+import os
+import secrets
+import shutil
+import socket
+import tempfile
+import threading
+import time
+
+
+_shared_wire_rns = None
+_shared_wire_config_dir = None
+
+_instances = {}
+_instances_lock = threading.Lock()
+
+
+def _get_rns():
+    """Return the real (not stub) RNS module.
+
+    Imported lazily for the same reason behavioral_transport does it —
+    the crypto-only code paths stub out RNS with fake modules, so we
+    route through the bridge's full-RNS helper.
+    """
+    from bridge_server import _get_full_rns
+    return _get_full_rns()
+
+
+def _allocate_free_port() -> int:
+    """Bind a loopback socket to port 0, read the OS-assigned port, close.
+
+    There's a tiny race window between close and re-bind, but on localhost
+    with a single test it's essentially never-observed. Same trick pytest-xdist
+    and most network test frameworks use.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+def _write_ifac_ini(
+    config_dir: str,
+    iface_name: str,
+    iface_block: str,
+    network_name: str,
+    passphrase: str,
+):
+    """Write a minimal RNS config with a single interface.
+
+    `iface_block` is the full interface type/target/port block; this helper
+    adds the `[reticulum]` header, the shared IFAC fields (if any), and
+    wraps the interface block.
+    """
+    os.makedirs(config_dir, exist_ok=True)
+    config_file = os.path.join(config_dir, "config")
+
+    ifac_lines = ""
+    if network_name:
+        ifac_lines += f"    network_name = {network_name}\n"
+    if passphrase:
+        ifac_lines += f"    passphrase = {passphrase}\n"
+
+    with open(config_file, "w") as f:
+        f.write(
+            "[reticulum]\n"
+            "  enable_transport = Yes\n"
+            "  share_instance = No\n"
+            "  respond_to_probes = No\n"
+            "\n"
+            "[interfaces]\n"
+            f"  [[{iface_name}]]\n"
+            f"{iface_block}"
+            f"{ifac_lines}"
+        )
+
+
+def _ensure_wire_rns_started(config_dir: str):
+    """Start the wire-mode Reticulum singleton once per bridge process.
+
+    Second calls with the same config are no-ops; second calls with a
+    different config raise (RNS.Reticulum is a process-wide singleton).
+    """
+    global _shared_wire_rns, _shared_wire_config_dir
+    RNS = _get_rns()
+
+    if _shared_wire_rns is not None:
+        if _shared_wire_config_dir != config_dir:
+            raise RuntimeError(
+                f"wire bridge already initialised with config_dir="
+                f"{_shared_wire_config_dir}; cannot reconfigure to "
+                f"{config_dir}. Spawn a fresh bridge subprocess for the "
+                f"other peer role."
+            )
+        return _shared_wire_rns
+
+    _shared_wire_config_dir = config_dir
+    RNS.loglevel = RNS.LOG_CRITICAL
+    _shared_wire_rns = RNS.Reticulum(
+        configdir=config_dir,
+        loglevel=RNS.LOG_CRITICAL,
+    )
+    return _shared_wire_rns
+
+
+def cmd_wire_start_tcp_server(params):
+    """Bring up RNS with a single TCPServerInterface on 127.0.0.1.
+
+    If bind_port=0 (default), pre-allocates a free port OS-side so both
+    impls can use the same "tell me a usable port" contract. The
+    returned `port` is what the client peer should connect to.
+    """
+    network_name = params.get("network_name") or ""
+    passphrase = params.get("passphrase") or ""
+    bind_port = int(params.get("bind_port", 0))
+
+    if bind_port == 0:
+        bind_port = _allocate_free_port()
+
+    config_dir = tempfile.mkdtemp(prefix="rns_wire_server_")
+    iface_block = (
+        "    type = TCPServerInterface\n"
+        "    enabled = Yes\n"
+        "    listen_ip = 127.0.0.1\n"
+        f"    listen_port = {bind_port}\n"
+    )
+    _write_ifac_ini(
+        config_dir,
+        "Wire TCP Server",
+        iface_block,
+        network_name,
+        passphrase,
+    )
+
+    RNS = _get_rns()
+    rns = _ensure_wire_rns_started(config_dir)
+    identity_hash = RNS.Transport.identity.hash
+
+    handle = secrets.token_hex(8)
+    with _instances_lock:
+        _instances[handle] = {
+            "rns": rns,
+            "config_dir": config_dir,
+            "identity_hash": identity_hash,
+            "role": "server",
+            "port": bind_port,
+            "destinations": [],
+        }
+
+    return {
+        "handle": handle,
+        "port": bind_port,
+        "identity_hash": identity_hash.hex(),
+    }
+
+
+def cmd_wire_start_tcp_client(params):
+    """Bring up RNS with a single TCPClientInterface pointing at a remote."""
+    network_name = params.get("network_name") or ""
+    passphrase = params.get("passphrase") or ""
+    target_host = params["target_host"]
+    target_port = int(params["target_port"])
+
+    config_dir = tempfile.mkdtemp(prefix="rns_wire_client_")
+    iface_block = (
+        "    type = TCPClientInterface\n"
+        "    enabled = Yes\n"
+        f"    target_host = {target_host}\n"
+        f"    target_port = {target_port}\n"
+    )
+    _write_ifac_ini(
+        config_dir,
+        "Wire TCP Client",
+        iface_block,
+        network_name,
+        passphrase,
+    )
+
+    RNS = _get_rns()
+    rns = _ensure_wire_rns_started(config_dir)
+    identity_hash = RNS.Transport.identity.hash
+
+    handle = secrets.token_hex(8)
+    with _instances_lock:
+        _instances[handle] = {
+            "rns": rns,
+            "config_dir": config_dir,
+            "identity_hash": identity_hash,
+            "role": "client",
+            "target_host": target_host,
+            "target_port": target_port,
+            "destinations": [],
+        }
+
+    return {"handle": handle, "identity_hash": identity_hash.hex()}
+
+
+def cmd_wire_announce(params):
+    """Create a fresh destination and announce it on all attached interfaces.
+
+    Each announce uses a newly-generated Identity (separate from the
+    Transport identity). That's the common pattern in production apps
+    and avoids conflating the announcer with the interface operator.
+    """
+    RNS = _get_rns()
+    handle = params["handle"]
+    app_name = params["app_name"]
+    aspects = params.get("aspects", [])
+    app_data_hex = params.get("app_data") or ""
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    identity = RNS.Identity()
+    destination = RNS.Destination(
+        identity,
+        RNS.Destination.IN,
+        RNS.Destination.SINGLE,
+        app_name,
+        *aspects,
+    )
+
+    app_data = bytes.fromhex(app_data_hex) if app_data_hex else None
+    destination.announce(app_data=app_data)
+    # Keep a reference so the destination/identity aren't GC'd before the
+    # TX loop picks up the announce packet.
+    inst["destinations"].append((identity, destination))
+
+    return {
+        "destination_hash": destination.hash.hex(),
+        "identity_hash": identity.hash.hex(),
+    }
+
+
+def cmd_wire_poll_path(params):
+    """Poll Transport.has_path until found or timeout.
+
+    Returns {found: True, hops: N} as soon as the destination appears in
+    the local path table. The presence of the path entry is the
+    observable proof that the remote's announce arrived AND passed IFAC
+    verification on this side.
+    """
+    RNS = _get_rns()
+    handle = params["handle"]
+    destination_hash = bytes.fromhex(params["destination_hash"])
+    timeout_ms = int(params.get("timeout_ms", 5000))
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    deadline = time.time() + (timeout_ms / 1000.0)
+    while time.time() < deadline:
+        if RNS.Transport.has_path(destination_hash):
+            hops = RNS.Transport.hops_to(destination_hash)
+            return {"found": True, "hops": int(hops)}
+        time.sleep(0.05)
+
+    return {"found": False, "hops": None}
+
+
+def cmd_wire_stop(params):
+    """Release resources for a wire-mode instance handle.
+
+    Note: Python RNS.Reticulum is a process-wide singleton and cannot be
+    fully torn down in-process, so we clean up bookkeeping and the
+    tempdir but leave the singleton alive. Intended pattern: one wire
+    test per bridge subprocess; the bridge dies with the fixture.
+    """
+    handle = params["handle"]
+    with _instances_lock:
+        inst = _instances.pop(handle, None)
+    if inst is None:
+        return {"stopped": False}
+
+    config_dir = inst.get("config_dir")
+    if config_dir and os.path.isdir(config_dir):
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+    return {"stopped": True}
+
+
+WIRE_COMMANDS = {
+    "wire_start_tcp_server": cmd_wire_start_tcp_server,
+    "wire_start_tcp_client": cmd_wire_start_tcp_client,
+    "wire_announce": cmd_wire_announce,
+    "wire_poll_path": cmd_wire_poll_path,
+    "wire_stop": cmd_wire_stop,
+}

--- a/tests/test_ifac.py
+++ b/tests/test_ifac.py
@@ -1,0 +1,163 @@
+"""IFAC (Interface Authentication Code) conformance tests.
+
+Covers the IFAC interface-authentication layer across implementations:
+  - HKDF key derivation from (network_name, passphrase) via IFAC_SALT
+  - Ed25519 signature-tag computation
+  - Wire-format masking and unmasking transforms
+
+Motivated by reticulum-kt issue #29: Kotlin's native IFAC produces wire
+bytes that Python RNS cannot verify, causing silent drops at the receiving
+side's IFAC check. No error surfaces to the user because a failing IFAC
+verify is indistinguishable from "not addressed to me".
+
+IFAC is pure deterministic crypto (HKDF + RFC 8032 Ed25519) — no timing,
+no state — so byte-equality across impls is the correct assertion.
+"""
+
+import hashlib
+
+from conftest import random_hex, assert_hex_equal
+
+
+def _ifac_origin_hex(network_name: str, passphrase: str) -> str:
+    """ifac_origin = SHA256(network_name) || SHA256(passphrase).
+
+    Computed test-side rather than via the bridge so the test author controls
+    the input domain — the bridge takes the origin already assembled.
+    """
+    return (
+        hashlib.sha256(network_name.encode()).digest()
+        + hashlib.sha256(passphrase.encode()).digest()
+    ).hex()
+
+
+def test_ifac_derive_key(sut, reference):
+    """HKDF-derived 64-byte IFAC key must match byte-for-byte.
+
+    The bridge's derive_key uses the fixed IFAC_SALT baked into both
+    implementations. A mismatch here would point at HKDF, HMAC, or the
+    salt constant diverging.
+    """
+    origin = _ifac_origin_hex("testnet", "testpass")
+    ref = reference.execute("ifac_derive_key", ifac_origin=origin)
+    res = sut.execute("ifac_derive_key", ifac_origin=origin)
+    assert_hex_equal(res["ifac_key"], ref["ifac_key"])
+    assert_hex_equal(res["ifac_salt"], ref["ifac_salt"])
+
+
+def test_ifac_compute_issue_29_vector(sut, reference):
+    """Exact repro vector from reticulum-kt#29: ("testnet", "testpass",
+    packet=bytes(range(64))). The reporter showed Kotlin's bytes diverge
+    from Python's here. Failure of this test is the headline symptom.
+    """
+    origin = _ifac_origin_hex("testnet", "testpass")
+    key_info = reference.execute("ifac_derive_key", ifac_origin=origin)
+    ifac_key = key_info["ifac_key"]
+    packet = bytes(range(64)).hex()
+
+    ref = reference.execute("ifac_compute", ifac_key=ifac_key, packet_data=packet)
+    res = sut.execute("ifac_compute", ifac_key=ifac_key, packet_data=packet)
+    assert_hex_equal(
+        res["signature"], ref["signature"],
+        "Ed25519 signatures diverge — RFC 8032 requires bit-identical output",
+    )
+    assert_hex_equal(res["ifac"], ref["ifac"])
+
+
+def test_ifac_compute_random(sut, reference):
+    """Fuzz ifac_compute with random key+packet inputs.
+
+    Ed25519 is deterministic, so any divergence across impls is a bug.
+    """
+    ifac_key = random_hex(64)
+    packet = random_hex(48)
+    ref = reference.execute("ifac_compute", ifac_key=ifac_key, packet_data=packet)
+    res = sut.execute("ifac_compute", ifac_key=ifac_key, packet_data=packet)
+    assert_hex_equal(res["ifac"], ref["ifac"])
+    assert_hex_equal(res["signature"], ref["signature"])
+
+
+def test_ifac_compute_variable_size(sut, reference):
+    """ifac_size selects how many trailing signature bytes form the tag.
+    Both impls must agree for every size production might use.
+    """
+    ifac_key = random_hex(64)
+    packet = random_hex(24)
+    for size in (1, 8, 16, 32, 64):
+        ref = reference.execute(
+            "ifac_compute", ifac_key=ifac_key, packet_data=packet, ifac_size=size
+        )
+        res = sut.execute(
+            "ifac_compute", ifac_key=ifac_key, packet_data=packet, ifac_size=size
+        )
+        assert_hex_equal(
+            res["ifac"], ref["ifac"],
+            f"ifac_compute diverges at ifac_size={size}",
+        )
+
+
+def test_ifac_verify_cross_impl(sut, reference):
+    """End-to-end interop check: SUT-computed tag must validate under the
+    reference, and vice-versa. This is the test that most directly models
+    what fails in production — a tag arrives on the wire from one impl and
+    is handed to the other's verifier.
+    """
+    ifac_key = random_hex(64)
+    packet = random_hex(32)
+
+    # SUT computes tag; reference verifies.
+    sut_compute = sut.execute("ifac_compute", ifac_key=ifac_key, packet_data=packet)
+    ref_verify = reference.execute(
+        "ifac_verify",
+        ifac_key=ifac_key,
+        packet_data=packet,
+        expected_ifac=sut_compute["ifac"],
+    )
+    assert ref_verify["valid"] is True, (
+        "Reference rejected SUT-produced IFAC tag. This is the exact "
+        "failure mode described in reticulum-kt#29 — Python won't "
+        "accept the Kotlin wire bytes, producing silent drops."
+    )
+
+    # Reference computes tag; SUT verifies.
+    ref_compute = reference.execute(
+        "ifac_compute", ifac_key=ifac_key, packet_data=packet
+    )
+    sut_verify = sut.execute(
+        "ifac_verify",
+        ifac_key=ifac_key,
+        packet_data=packet,
+        expected_ifac=ref_compute["ifac"],
+    )
+    assert sut_verify["valid"] is True, (
+        "SUT rejected reference-produced IFAC tag — SUT cannot verify "
+        "Python's wire bytes."
+    )
+
+
+def test_ifac_mask_packet(sut, reference):
+    """Full wire-format masking transform byte-equality.
+
+    Covers: Ed25519 signing + header-flag toggle + IFAC insertion + HKDF
+    mask derivation (salt=ifac_key, ikm=ifac) + XOR-mask application.
+    Any divergence in any step produces different masked bytes.
+
+    Uses a 2-byte header with the IFAC flag clear (0x00) so the mask
+    transform runs end-to-end. Real packets vary the low bits of byte 0,
+    but the flag bit (0x80) must be clear on input.
+    """
+    ifac_key = random_hex(64)
+    header = bytes([0x00, 0x00]).hex()
+    payload = random_hex(32)
+    packet = header + payload
+
+    ref = reference.execute(
+        "ifac_mask_packet", ifac_key=ifac_key, packet_data=packet
+    )
+    res = sut.execute("ifac_mask_packet", ifac_key=ifac_key, packet_data=packet)
+    assert_hex_equal(res["ifac"], ref["ifac"])
+    assert_hex_equal(
+        res["masked_packet"], ref["masked_packet"],
+        "Masked-packet bytes diverge — the on-wire bytes the SUT would "
+        "emit cannot be parsed by Python's IFAC unmasker.",
+    )

--- a/tests/wire/conftest.py
+++ b/tests/wire/conftest.py
@@ -1,0 +1,173 @@
+"""Wire-level (E2E) fixtures.
+
+Unlike byte-level tests (one bridge as sut, one as reference, each fed test
+vectors) and unlike behavioral tests (one bridge with MockInterface-buffered
+packets), wire tests pair TWO live Reticulum instances over a loopback TCP
+link and observe the result of real packet exchange.
+
+The `wire_peers` fixture spawns two bridge subprocesses — one server-role,
+one client-role — with caller-selectable impls. Each bridge is fresh per
+test (Python RNS is a process-singleton; Kotlin's Reticulum.stop() works
+but the bridge boundary is simpler to reason about with fresh processes).
+
+See reference/wire_tcp.py and conformance-bridge/src/main/kotlin/WireTcp.kt
+for the `wire_*` command surface these fixtures drive.
+"""
+
+import os
+import secrets
+
+import pytest
+
+from bridge_client import BridgeClient
+from conftest import get_impl_list, resolve_command
+
+
+def _env_for(impl: str) -> dict:
+    """Env vars the reference Python bridge needs; Kotlin ignores them."""
+    if impl != "reference":
+        return {}
+    return {
+        "PYTHON_RNS_PATH": os.environ.get(
+            "PYTHON_RNS_PATH",
+            os.path.expanduser("~/repos/Reticulum"),
+        ),
+        "PYTHON_LXMF_PATH": os.environ.get(
+            "PYTHON_LXMF_PATH",
+            os.path.expanduser("~/repos/LXMF"),
+        ),
+    }
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize wire tests over EVERY (server_impl, client_impl) pair.
+
+    For impls ["reference", "kotlin"] that's 4 pairs per test. The
+    homogeneous pairs (reference↔reference, kotlin↔kotlin) are useful
+    smoke tests: they isolate whether a failure is interop-specific vs.
+    just broken end-to-end on one side. The heterogeneous pairs are the
+    real cross-impl assertion.
+    """
+    if "wire_pair" in metafunc.fixturenames:
+        impls = get_impl_list(metafunc.config) or []
+        # Always include the reference so a cross-impl test actually tests
+        # something; a single-impl run (e.g. --impl kotlin with no reference
+        # in the impl list) would otherwise skip the whole interop point.
+        peers = sorted(set(impls) | {"reference"})
+        pairs = [(a, b) for a in peers for b in peers]
+        ids = [f"{a}-to-{b}" for a, b in pairs]
+        metafunc.parametrize("wire_pair", pairs, ids=ids, scope="function")
+
+
+class _WirePeer:
+    """Thin convenience wrapper around a BridgeClient.
+
+    Holds the peer's handle and exposes the five wire_* commands as methods.
+    Each method just forwards to `bridge.execute` and returns the decoded
+    response fields the tests care about.
+    """
+
+    def __init__(self, bridge: BridgeClient, role_label: str):
+        self.bridge = bridge
+        self.role_label = role_label  # purely for error messages
+        self.handle: str | None = None
+        self.identity_hash: bytes | None = None
+        self.port: int | None = None
+
+    def start_tcp_server(self, network_name: str, passphrase: str) -> int:
+        resp = self.bridge.execute(
+            "wire_start_tcp_server",
+            network_name=network_name,
+            passphrase=passphrase,
+        )
+        self.handle = resp["handle"]
+        self.identity_hash = bytes.fromhex(resp["identity_hash"])
+        self.port = int(resp["port"])
+        return self.port
+
+    def start_tcp_client(
+        self, network_name: str, passphrase: str, target_host: str, target_port: int
+    ):
+        resp = self.bridge.execute(
+            "wire_start_tcp_client",
+            network_name=network_name,
+            passphrase=passphrase,
+            target_host=target_host,
+            target_port=target_port,
+        )
+        self.handle = resp["handle"]
+        self.identity_hash = bytes.fromhex(resp["identity_hash"])
+
+    def announce(self, app_name: str, aspects: list, app_data: bytes = b"") -> bytes:
+        assert self.handle, "start_* must be called first"
+        resp = self.bridge.execute(
+            "wire_announce",
+            handle=self.handle,
+            app_name=app_name,
+            aspects=list(aspects),
+            app_data=app_data.hex(),
+        )
+        return bytes.fromhex(resp["destination_hash"])
+
+    def poll_path(self, destination_hash: bytes, timeout_ms: int = 5000) -> bool:
+        assert self.handle, "start_* must be called first"
+        resp = self.bridge.execute(
+            "wire_poll_path",
+            handle=self.handle,
+            destination_hash=destination_hash.hex(),
+            timeout_ms=timeout_ms,
+        )
+        return bool(resp.get("found"))
+
+    def stop(self):
+        if self.handle is None:
+            return
+        try:
+            self.bridge.execute("wire_stop", handle=self.handle)
+        except Exception:
+            pass
+        self.handle = None
+
+
+@pytest.fixture
+def wire_pair(request):
+    """Return (server_impl, client_impl) tuple from pytest_generate_tests."""
+    return request.param
+
+
+@pytest.fixture
+def wire_peers(wire_pair):
+    """Two freshly-spawned bridge subprocesses, one server-role, one client-role.
+
+    Yields (server, client) as `_WirePeer` objects. Caller is responsible for
+    calling `server.start_tcp_server(...)` and `client.start_tcp_client(...)`
+    with the port the server returns. Both bridges are torn down in the
+    fixture finalizer regardless of whether the test raised.
+    """
+    server_impl, client_impl = wire_pair
+    server_bridge = BridgeClient(
+        resolve_command(server_impl), env=_env_for(server_impl)
+    )
+    client_bridge = BridgeClient(
+        resolve_command(client_impl), env=_env_for(client_impl)
+    )
+    server = _WirePeer(server_bridge, role_label=f"server({server_impl})")
+    client = _WirePeer(client_bridge, role_label=f"client({client_impl})")
+
+    try:
+        yield server, client
+    finally:
+        # Stop both peers before tearing down the pipe — mirrors the
+        # behavioral fixture pattern so an in-process teardown hook on
+        # the bridge side (e.g. Reticulum.stop) gets a chance to run
+        # cleanly before its stdin closes.
+        for peer in (server, client):
+            try:
+                peer.stop()
+            except Exception:
+                pass
+        for b in (server_bridge, client_bridge):
+            try:
+                b.close()
+            except Exception:
+                pass

--- a/tests/wire/test_ifac_interop.py
+++ b/tests/wire/test_ifac_interop.py
@@ -1,0 +1,152 @@
+"""End-to-end IFAC wire-interop tests.
+
+Reproduces the exact failure mode from reticulum-kt#29:
+
+  Two Reticulum instances configured with the same (network_name, passphrase),
+  connected over a single TCPClient↔TCPServer link, cannot see each other's
+  announces because one side's IFAC bytes don't verify on the other side.
+
+Unlike byte-level IFAC tests (tests/test_ifac.py) that compare primitives in
+isolation, this test exercises the FULL transmit→mask→wire→unmask→validate
+pipeline end-to-end. A failure here means announces aren't crossing the
+IFAC boundary in at least one direction — the production symptom.
+
+Parametrized over (server_impl, client_impl) pairs by `pytest_generate_tests`
+in the local conftest. That yields, for a [reference, kotlin] impl list:
+  - reference ↔ reference  (sanity baseline — must pass)
+  - reference ↔ kotlin     (issue-#29 direction A)
+  - kotlin ↔ reference     (issue-#29 direction B)
+  - kotlin ↔ kotlin        (Kotlin self-interop baseline)
+"""
+
+import secrets
+import time
+
+import pytest
+
+
+def _fresh_credentials() -> tuple[str, str]:
+    """Random but deterministic-looking (network_name, passphrase) pair.
+
+    Using a fresh pair per test avoids any accidental cross-contamination
+    with a real Reticulum network on the machine running the tests.
+    """
+    return (
+        f"conftest-{secrets.token_hex(4)}",
+        secrets.token_hex(16),
+    )
+
+
+# How long to wait between starting the client and triggering the announce.
+# The TCPClient connect is asynchronous and announces before the connection
+# is up will be silently dropped by the unconnected interface.
+_CONNECT_SETTLE_SEC = 0.75
+
+# Upper bound on how long an announce should take to traverse the link and
+# populate the peer's path table. Announces are sent immediately; path
+# learning is synchronous on inbound — so this mostly tolerates scheduler
+# jitter, not real transport latency.
+_POLL_TIMEOUT_MS = 5000
+
+
+def test_announce_propagates_with_ifac(wire_peers):
+    """A client's announce must land in the server's path table when both
+    sides have matching IFAC credentials.
+
+    Failure semantic: "IFAC bytes produced by <client_impl> cannot be
+    verified by <server_impl>, so the server silently dropped the announce."
+    This is the headline reticulum-kt#29 interop break.
+    """
+    server, client = wire_peers
+    network_name, passphrase = _fresh_credentials()
+
+    port = server.start_tcp_server(network_name, passphrase)
+    client.start_tcp_client(network_name, passphrase, "127.0.0.1", port)
+
+    time.sleep(_CONNECT_SETTLE_SEC)
+
+    dest_hash = client.announce(
+        app_name="interop",
+        aspects=["ifac", "test"],
+        app_data=b"hello",
+    )
+
+    found = server.poll_path(dest_hash, timeout_ms=_POLL_TIMEOUT_MS)
+    assert found, (
+        f"{server.role_label} did not learn path to destination announced "
+        f"by {client.role_label} within {_POLL_TIMEOUT_MS}ms. Both sides "
+        f"configured matching IFAC ({network_name=}). The most likely "
+        f"cause is that {client.role_label}'s IFAC wire bytes did not "
+        f"pass {server.role_label}'s IFAC unmask — i.e. reticulum-kt#29 "
+        f"reproduces for this direction."
+    )
+
+
+def test_announce_bidirectional(wire_peers):
+    """Additionally verify the reverse direction: server announces, client
+    learns the path. The one-direction test above covers client→server; this
+    covers server→client, which exercises the TCP spawn-on-accept code path
+    that Python's TCPServerInterface uses (child interfaces inherit IFAC —
+    see RNS/Interfaces/TCPInterface.py:588-590).
+    """
+    server, client = wire_peers
+    network_name, passphrase = _fresh_credentials()
+
+    port = server.start_tcp_server(network_name, passphrase)
+    client.start_tcp_client(network_name, passphrase, "127.0.0.1", port)
+
+    time.sleep(_CONNECT_SETTLE_SEC)
+
+    dest_hash = server.announce(
+        app_name="interop",
+        aspects=["reverse"],
+        app_data=b"reverse",
+    )
+
+    found = client.poll_path(dest_hash, timeout_ms=_POLL_TIMEOUT_MS)
+    assert found, (
+        f"{client.role_label} did not learn path to destination announced "
+        f"by {server.role_label} within {_POLL_TIMEOUT_MS}ms. This is the "
+        f"reverse-direction failure mode: the server's IFAC bytes did not "
+        f"pass the client's IFAC unmask."
+    )
+
+
+@pytest.mark.parametrize(
+    "server_secret,client_secret",
+    [
+        ("right-netname", "right-pass"),   # baseline — both right
+    ],
+    ids=["matching-credentials"],
+)
+def test_mismatched_ifac_blocks_announce(wire_peers, server_secret, client_secret):
+    """Negative-control: when network_names match but passphrases differ,
+    the link MUST NOT propagate announces. This protects us against a
+    regression where one side stops enforcing IFAC entirely — which would
+    make the positive tests above pass for the wrong reason.
+
+    Server uses (server_secret, "pass-A"); client uses (server_secret, "pass-B").
+    """
+    server, client = wire_peers
+
+    port = server.start_tcp_server(server_secret, "pass-A")
+    client.start_tcp_client(server_secret, "pass-B", "127.0.0.1", port)
+
+    time.sleep(_CONNECT_SETTLE_SEC)
+
+    dest_hash = client.announce(
+        app_name="interop",
+        aspects=["neg"],
+        app_data=b"neg",
+    )
+
+    # Use a shorter timeout; we're asserting NOT found, so waiting the full
+    # budget just adds latency without changing the outcome.
+    found = server.poll_path(dest_hash, timeout_ms=2000)
+    assert not found, (
+        f"{server.role_label} learned a path for an announce signed with a "
+        f"different IFAC passphrase. Either {server.role_label} is not "
+        f"enforcing IFAC at all, or both sides derived the same key from "
+        f"different passphrases (HKDF collision — effectively impossible). "
+        f"This would make the positive-direction interop tests meaningless."
+    )


### PR DESCRIPTION
## Summary

Two layers of IFAC conformance tests motivated by [reticulum-kt#29](https://github.com/torlando-tech/reticulum-kt/issues/29), which reported Kotlin-emitted IFAC bytes not verifying on the Python receiver:

- **Byte-level** (`tests/test_ifac.py`, 6 tests): compares HKDF key derivation, Ed25519 signature tags, full wire masking transforms byte-for-byte between impls. Uses the existing `sut`/`reference` session-scoped bridge fixtures.

- **Wire E2E** (`tests/wire/test_ifac_interop.py`, 3 tests × 4 impl pairs = 12 cases): pairs TWO live Reticulum instances over loopback TCP with matching IFAC and observes whether announces propagate. This is the only layer that reproduces the reported production symptom. Backed by a new `reference/wire_tcp.py` bridge module (5 commands) and matching `WireTcp.kt` in reticulum-kt (PR link below).

## Results against current HEAD

All 18 tests pass, including:
- `kotlin-to-reference` and `reference-to-kotlin` positive announces
- `kotlin-to-kotlin` self-interop
- Negative control (mismatched passphrase) correctly blocks propagation in every pair

Combined, this strongly suggests issue #29 has been fixed since the report — no IFAC divergence is observable at any layer of the stack. The tests now serve as regression protection.

## Coordination

The wire E2E tests require torlando-tech/reticulum-kt#[pending] to land first (adds the `wire_*` command handlers). Without that, the wire tests would hit `Unknown command: wire_start_tcp_server` on kotlin-role peers.

## Test plan

- [x] Python-only: `pytest tests/ --reference-only` green
- [x] Cross-impl: `pytest tests/test_ifac.py tests/wire/ --impl=kotlin` → 18/18 pass
- [ ] CI passes once the reticulum-kt PR lands
- [ ] Greptile review: 5/5, zero unresolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)