### PR TITLE
Tighten resource assertions to exact equality

### DIFF
--- a/tests/wire/test_resource_multihop.py
+++ b/tests/wire/test_resource_multihop.py
@@ -118,7 +118,7 @@ def test_small_resource_multihop(wire_trio, wire_3peer):
     )
 
     received = receiver.resource_poll(dest_hash, timeout_ms=_RESOURCE_TIMEOUT_MS)
-    assert payload in received, (
+    assert received == [payload], (
         f"{receiver.role_label} did not receive the 256-byte resource "
         f"from {sender.role_label}. Got {len(received)} resource(s): "
         f"{[r[:20].hex() + '...' for r in received]}."
@@ -144,7 +144,7 @@ def test_chunked_resource_multihop(wire_trio, wire_3peer):
     )
 
     received = receiver.resource_poll(dest_hash, timeout_ms=_RESOURCE_TIMEOUT_MS)
-    assert payload in received, (
+    assert received == [payload], (
         f"{receiver.role_label} did not reassemble the {len(payload)}-byte "
         f"resource from {sender.role_label}. Sender reported "
         f"success={send_resp.get('success')} status={send_resp.get('status')}, "
@@ -179,7 +179,7 @@ def test_chunked_resource_with_ifac_multihop(wire_trio, wire_3peer):
     )
 
     received = receiver.resource_poll(dest_hash, timeout_ms=_RESOURCE_TIMEOUT_MS)
-    assert payload in received, (
+    assert received == [payload], (
         f"{receiver.role_label} did not reassemble the {len(payload)}-byte "
         f"IFAC-protected resource from {sender.role_label}."
     )
@@ -206,7 +206,7 @@ def test_large_resource_multihop(wire_trio, wire_3peer):
     )
 
     received = receiver.resource_poll(dest_hash, timeout_ms=60_000)
-    assert payload in received, (
+    assert received == [payload], (
         f"{receiver.role_label} did not reassemble the {len(payload)}-byte "
         f"resource from {sender.role_label}."
     )


### PR DESCRIPTION
Change \`assert payload in received\` to \`assert received == [payload]\`
in all four resource tests.

The membership-based check passed even when the receiver enqueued
the same payload more than once — which the Kotlin bridge was
actually doing, masked by the loose assertion. Greptile spotted
the cause: reticulum-kt's \`Resource.assemble()\` invokes
\`Link.resourceConcluded\` twice for every completed transfer
(\`Resource.kt:1194\` direct call, \`Resource.kt:1200\` via the
callback set up by \`Link.ACCEPT_ALL\`'s \`Resource.accept\`). Each
invocation spawns its own daemon thread that lands in the
user-set \`setResourceConcludedCallback\`, so the bridge's listener
buffer got the same payload appended twice.

The matching fix in reticulum-kt#40 deduplicates at the bridge
callback boundary, so every transfer now yields exactly one buffer
entry.

Tightening the assertion here catches any future regression to
either the bridge dedup or the upstream \`Resource.assemble\`
double-fire that reintroduces duplicate delivery.

## Test plan
- [x] \`pytest tests/wire/test_resource_multihop.py --impl=kotlin\` -> 16 pass / 16 xfail / 0 fail with the reticulum-kt dedup fix; the same suite reliably showed duplicates before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)