### PR TITLE
Add LXMF propagation conformance suite (4-combo matrix)

### DIFF
--- a/reference/bridge_server.py
+++ b/reference/bridge_server.py
@@ -4734,6 +4734,15 @@ try:
 except ImportError:
     pass
 
+# LXMF-layer conformance commands (propagation E2E tests). Layered on top
+# of wire_tcp — lxmf_start binds to an existing wire handle rather than
+# reinitializing RNS. See lxmf_bridge.py for the rationale.
+try:
+    from lxmf_bridge import LXMF_COMMANDS
+    COMMANDS.update(LXMF_COMMANDS)
+except ImportError:
+    pass
+
 
 def handle_request(request):
     """Process a single request and return response."""

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -649,10 +649,10 @@ def cmd_lxmf_sync_inbound(params):
     """Ask this peer's LXMRouter to fetch stored messages from its
     configured outbound propagation node.
 
-    Blocks until the transfer finishes (COMPLETE / FAILED / timeout).
-    Returns the number of messages retrieved — NOT necessarily delivered
-    to the callback yet. Callers should follow with lxmf_poll_inbox to
-    actually drain the delivered messages.
+    Blocks until the transfer finishes (COMPLETE / FAILED / timeout) AND
+    the delivery callbacks for the transferred messages have populated
+    the inbox — so callers can immediately poll_inbox and see the full
+    set of received messages without racing the router's worker threads.
 
     params:
         handle (str): lxmf_start handle.
@@ -674,9 +674,7 @@ def cmd_lxmf_sync_inbound(params):
 
     LXMF = _get_lxmf()
     router = inst["router"]
-    router.request_messages_from_propagation_node(inst["identity"])
 
-    # Wait for the transfer state machine to settle into a terminal state.
     # Python LXMF's state names are prefixed PR_* as module-level ints.
     terminal_states = {
         LXMF.LXMRouter.PR_COMPLETE,
@@ -684,20 +682,54 @@ def cmd_lxmf_sync_inbound(params):
         LXMF.LXMRouter.PR_NO_IDENTITY_RCVD,
         LXMF.LXMRouter.PR_NO_ACCESS,
     }
+
+    # Snapshot the inbox size BEFORE we kick off the transfer. The poll
+    # loop below waits for new messages to actually land in the inbox,
+    # not just for the transfer state machine to report a count — this
+    # closes two races at once:
+    #   1. Stale terminal state: `propagation_transfer_state` may still
+    #      be PR_COMPLETE from a previous sync. Even though LXMRouter.
+    #      request_messages_from_propagation_node synchronously
+    #      transitions the state on the common path (link active or
+    #      re-establishing), a fast first poll otherwise has no guard
+    #      against reading the previous transfer's PR_COMPLETE.
+    #   2. Callback drain: delivery callbacks run on the router's own
+    #      threads; the transfer reaching PR_COMPLETE doesn't guarantee
+    #      the callbacks have fired yet. The previous `time.sleep(0.3)`
+    #      after the state settled was an empirical constant with no
+    #      guaranteed relationship to callback completion time.
+    with inst["inbox_lock"]:
+        inbox_size_before = len(inst["inbox"])
+
+    router.request_messages_from_propagation_node(inst["identity"])
+
     deadline = time.time() + (timeout_ms / 1000.0)
+    observed_non_terminal = False
     while time.time() < deadline:
         state = router.propagation_transfer_state
-        if state in terminal_states:
-            break
-        time.sleep(0.1)
+        if state not in terminal_states:
+            observed_non_terminal = True
+        # Only consider a terminal state final if we've observed the
+        # transfer leave the initial state at least once (defeats (1)).
+        # Exception: request_messages_from_propagation_node set the
+        # state synchronously on the common path, so if the FIRST poll
+        # already shows a non-terminal state, we're mid-transfer and
+        # the flag catches up on the next iteration.
+        if state in terminal_states and observed_non_terminal:
+            last_result = int(router.propagation_transfer_last_result or 0)
+            expected_inbox_size = inbox_size_before + last_result
+            with inst["inbox_lock"]:
+                current_inbox_size = len(inst["inbox"])
+            # Wait for the delivery callbacks to have caught up with the
+            # transfer count. This is the callback-drain guarantee (2):
+            # we return only when poll_inbox will actually see the
+            # messages that sync_inbound reports.
+            if current_inbox_size >= expected_inbox_size:
+                break
+        time.sleep(0.05)
 
     final_state = router.propagation_transfer_state
     last_result = int(router.propagation_transfer_last_result or 0)
-
-    # Let any freshly-decrypted messages hit the delivery callback before
-    # we return — callbacks run on the router's own threads and the caller
-    # is about to poll the inbox.
-    time.sleep(0.3)
 
     return {
         "messages_received": last_result,

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -386,10 +386,25 @@ def cmd_lxmf_spawn_daemon_propagation_node(params):
                     pass
             reader_done.set()
 
+    # Thread start is the only place _tail_lxmd.finally runs, and that's
+    # the only place lxmd_logfile is closed. If Thread.start itself raises
+    # (OS thread-limit, memory pressure), _tail_lxmd never runs and the
+    # logfile leaks. Also handle lxmd_proc in the same guard so a thread-
+    # start failure doesn't leak the subprocess pipe either.
     reader_thread = threading.Thread(
         target=_tail_lxmd, name=f"lxmd-tail-{wire_handle}", daemon=True
     )
-    reader_thread.start()
+    try:
+        reader_thread.start()
+    except Exception:
+        if lxmd_logfile:
+            try:
+                lxmd_logfile.close()
+            except Exception:
+                pass
+        _terminate_lxmd(lxmd_proc)
+        _cleanup_lxmd_dir(lxmd_config_dir)
+        raise
 
     # Wait for the startup line, the process exiting early, or timeout.
     deadline = time.time() + startup_timeout_sec
@@ -701,6 +716,15 @@ def cmd_lxmf_sync_inbound(params):
     with inst["inbox_lock"]:
         inbox_size_before = len(inst["inbox"])
 
+    # Snapshot the pre-call state. A terminal state that DIFFERS from
+    # this pre-call value means the state machine actually transitioned
+    # (e.g. PR_COMPLETE -> PR_FAILED on an immediately-rejected link),
+    # so we don't need to see a non-terminal state first to accept it.
+    # This closes a slow-failure path where LXMF goes straight to a
+    # terminal state without ever leaving the initial one — previously
+    # the loop burned the full timeout_ms before returning the failure.
+    state_before = router.propagation_transfer_state
+
     router.request_messages_from_propagation_node(inst["identity"])
 
     deadline = time.time() + (timeout_ms / 1000.0)
@@ -709,13 +733,18 @@ def cmd_lxmf_sync_inbound(params):
         state = router.propagation_transfer_state
         if state not in terminal_states:
             observed_non_terminal = True
-        # Only consider a terminal state final if we've observed the
-        # transfer leave the initial state at least once (defeats (1)).
-        # Exception: request_messages_from_propagation_node set the
-        # state synchronously on the common path, so if the FIRST poll
-        # already shows a non-terminal state, we're mid-transfer and
-        # the flag catches up on the next iteration.
-        if state in terminal_states and observed_non_terminal:
+        # Only consider a terminal state final if either:
+        #   (a) we've observed the transfer leave the initial state at
+        #       least once (common happy path: state goes
+        #       LINK_ESTABLISHED -> REQUESTING_MESSAGES -> PR_COMPLETE,
+        #       defeating the stale PR_COMPLETE race), or
+        #   (b) the current terminal state differs from the one observed
+        #       before request_messages_from_propagation_node was called
+        #       — this catches fast-failure paths that go straight to a
+        #       new terminal state without passing through any
+        #       non-terminal state first, so we fail fast instead of
+        #       burning the full timeout budget.
+        if state in terminal_states and (observed_non_terminal or state != state_before):
             last_result = int(router.propagation_transfer_last_result or 0)
             expected_inbox_size = inbox_size_before + last_result
             with inst["inbox_lock"]:

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -681,8 +681,15 @@ def cmd_lxmf_send_propagated(params):
             f"Failed to generate propagation stamp for {message.transient_id!r} "
             f"at cost {target_cost}. LXStamper.generate_stamp returned None."
         )
+    # LXMF's get_propagation_stamp already sets propagation_stamp and
+    # propagation_stamp_valid on the success path (LXMessage.py:352-354),
+    # so these two assignments are defensive-redundant. Kept for clarity
+    # and to guard against any future LXMF change that moves the write.
     message.propagation_stamp = generated_stamp
     message.propagation_stamp_valid = True
+    # defer_stamp / defer_propagation_stamp ARE read by handle_outbound
+    # (LXMRouter.py:1669, 1673) — the whole point of this function is
+    # to force the non-deferred path. These assignments are load-bearing.
     message.defer_stamp = False
     message.defer_propagation_stamp = False
     # pack() must be re-run after the stamp is attached (LXMessage.pack
@@ -797,6 +804,26 @@ def cmd_lxmf_sync_inbound(params):
 
     final_state = router.propagation_transfer_state
     last_result = int(router.propagation_transfer_last_result or 0)
+
+    # Preserve the "blocks until callbacks have fired" guarantee even on
+    # the timeout path. Scenario this closes: transfer reaches PR_COMPLETE
+    # at second 14.99 of a 15s timeout, callback hasn't fired yet, the
+    # outer `while time.time() < deadline` expires — without this guard,
+    # sync_inbound would return messages_received=1 while poll_inbox sees
+    # an empty list, causing a confusing "sync says 1, inbox is 0"
+    # mismatch downstream. Use a short post-loop spin bounded to 500ms so
+    # a genuine transfer failure still returns within 15.5s instead of
+    # stretching further toward 30s.
+    expected_inbox_size = inbox_size_before + last_result
+    with inst["inbox_lock"]:
+        current_inbox_size = len(inst["inbox"])
+    if current_inbox_size < expected_inbox_size:
+        spin_deadline = time.time() + 0.5
+        while time.time() < spin_deadline:
+            time.sleep(0.05)
+            with inst["inbox_lock"]:
+                if len(inst["inbox"]) >= expected_inbox_size:
+                    break
 
     return {
         "messages_received": last_result,

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -851,7 +851,6 @@ def cmd_lxmf_stop(params):
     # process. We just clean up our own bookkeeping here.
     storage_path = inst.get("storage_path")
     if storage_path and os.path.isdir(storage_path):
-        import shutil
         shutil.rmtree(storage_path, ignore_errors=True)
 
     return {"stopped": True}

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -288,121 +288,127 @@ def cmd_lxmf_spawn_daemon_propagation_node(params):
     #     PROPAGATION_COST (16); we use it as-is. LXMF-kt's sender reads
     #     the cost from the node's announce and generates a matching
     #     stamp. At cost=16 that's ~65k attempts (~2-5s) — acceptable.
+    # All resource allocation from here through reader_thread.start() is
+    # wrapped in a single guard: if anything raises (Popen EPERM despite
+    # shutil.which succeeding, log-file open EACCES, Thread.start()
+    # ENOMEM), we reverse-unwind whatever has already been allocated so
+    # the caller sees the original exception without leaking tempdirs,
+    # file handles, or subprocess pipes.
     lxmd_config_dir = tempfile.mkdtemp(prefix="lxmd_conf_")
-    lxmd_config_path = os.path.join(lxmd_config_dir, "config")
-    # CONFORMANCE_LXMD_LOGLEVEL overrides the default loglevel (4=Notice).
-    # Set to 7 (EXTREME) when debugging announce forwarding / path convergence
-    # issues — matches RNS.LOG_EXTREME and surfaces the "Sending announce"
-    # lines lxmd emits at that level.
-    lxmd_loglevel = int(os.environ.get("CONFORMANCE_LXMD_LOGLEVEL", "4"))
-    with open(lxmd_config_path, "w") as f:
-        f.write(
-            "[lxmf]\n"
-            f"  display_name = {display_name}\n"
-            "  announce_at_start = Yes\n"
-            "\n"
-            "[logging]\n"
-            f"  loglevel = {lxmd_loglevel}\n"
-            "\n"
-            "[propagation]\n"
-            "  enable_node = Yes\n"
-            f"  node_name = {display_name}\n"
-            "  announce_at_start = Yes\n"
-            "  message_storage_limit = 100\n"
-            "  propagation_message_max_accepted_size = 25000\n"
-            "  propagation_sync_max_accepted_size = 102400\n"
+    lxmd_proc = None
+    lxmd_logfile = None
+    try:
+        lxmd_config_path = os.path.join(lxmd_config_dir, "config")
+        # CONFORMANCE_LXMD_LOGLEVEL overrides the default loglevel (4=Notice).
+        # Set to 7 (EXTREME) when debugging announce forwarding / path convergence
+        # issues — matches RNS.LOG_EXTREME and surfaces the "Sending announce"
+        # lines lxmd emits at that level.
+        lxmd_loglevel = int(os.environ.get("CONFORMANCE_LXMD_LOGLEVEL", "4"))
+        with open(lxmd_config_path, "w") as f:
+            f.write(
+                "[lxmf]\n"
+                f"  display_name = {display_name}\n"
+                "  announce_at_start = Yes\n"
+                "\n"
+                "[logging]\n"
+                f"  loglevel = {lxmd_loglevel}\n"
+                "\n"
+                "[propagation]\n"
+                "  enable_node = Yes\n"
+                f"  node_name = {display_name}\n"
+                "  announce_at_start = Yes\n"
+                "  message_storage_limit = 100\n"
+                "  propagation_message_max_accepted_size = 25000\n"
+                "  propagation_sync_max_accepted_size = 102400\n"
+            )
+
+        # Spawn lxmd. Drop -s so stdout/stderr are text streams we can tail.
+        # --propagation-node is redundant with enable_node=Yes in the config
+        # but matches the production invocation and is belt-and-suspenders.
+        #
+        # PYTHONUNBUFFERED=1 is essential: when stdout is piped (not a tty),
+        # CPython buffers full blocks, which means the "Propagation Node
+        # started on <hex>" line won't reach our reader until lxmd emits
+        # several more log lines — and in practice lxmd goes quiet after
+        # startup, so without this we hit the 30s timeout even though lxmd
+        # is healthy. `text=True, bufsize=1` alone doesn't fix this because
+        # bufsize controls OUR pipe, not the child's internal stdio buffer.
+        child_env = dict(os.environ)
+        child_env["PYTHONUNBUFFERED"] = "1"
+        lxmd_proc = subprocess.Popen(
+            [
+                lxmd_path,
+                "--rnsconfig", rns_config_dir,
+                "--config", lxmd_config_dir,
+                "--propagation-node",
+                "-v",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,  # interleaved so the regex match wins
+            text=True,
+            bufsize=1,  # line-buffered on OUR pipe
+            env=child_env,
         )
 
-    # Spawn lxmd. Drop -s so stdout/stderr are text streams we can tail.
-    # --propagation-node is redundant with enable_node=Yes in the config
-    # but matches the production invocation and is belt-and-suspenders.
-    #
-    # PYTHONUNBUFFERED=1 is essential: when stdout is piped (not a tty),
-    # CPython buffers full blocks, which means the "Propagation Node
-    # started on <hex>" line won't reach our reader until lxmd emits
-    # several more log lines — and in practice lxmd goes quiet after
-    # startup, so without this we hit the 30s timeout even though lxmd
-    # is healthy. `text=True, bufsize=1` alone doesn't fix this because
-    # bufsize controls OUR pipe, not the child's internal stdio buffer.
-    child_env = dict(os.environ)
-    child_env["PYTHONUNBUFFERED"] = "1"
-    lxmd_proc = subprocess.Popen(
-        [
-            lxmd_path,
-            "--rnsconfig", rns_config_dir,
-            "--config", lxmd_config_dir,
-            "--propagation-node",
-            "-v",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,  # interleaved so the regex match wins
-        text=True,
-        bufsize=1,  # line-buffered on OUR pipe
-        env=child_env,
-    )
+        # Drain lxmd's stdout in a background thread so its pipe buffer can't
+        # fill and deadlock the child. We only actually care about the
+        # "Propagation Node started on <hex>" line; everything else is tee'd
+        # into a ring buffer for teardown-time diagnostics.
+        recent_output: list[str] = []
+        prop_dest_hex = [None]  # captured by the thread; single-slot mailbox
+        started_event = threading.Event()
+        reader_done = threading.Event()
 
-    # Drain lxmd's stdout in a background thread so its pipe buffer can't
-    # fill and deadlock the child. We only actually care about the
-    # "Propagation Node started on <hex>" line; everything else is tee'd
-    # into a ring buffer for teardown-time diagnostics.
-    recent_output: list[str] = []
-    prop_dest_hex = [None]  # captured by the thread; single-slot mailbox
-    started_event = threading.Event()
-    reader_done = threading.Event()
+        # Optional file-tee for debugging: if CONFORMANCE_LXMD_LOG is set, we
+        # also mirror lxmd's output there. Useful for diagnosing "lxmd is up
+        # but topology didn't converge" failures where the stderr/stdout ring
+        # buffer is discarded on success.
+        lxmd_logfile_path = os.environ.get("CONFORMANCE_LXMD_LOG")
+        lxmd_logfile = open(lxmd_logfile_path, "a") if lxmd_logfile_path else None
+        if lxmd_logfile:
+            lxmd_logfile.write(f"\n=== lxmd spawn (wire_handle={wire_handle}) ===\n")
+            lxmd_logfile.flush()
 
-    # Optional file-tee for debugging: if CONFORMANCE_LXMD_LOG is set, we
-    # also mirror lxmd's output there. Useful for diagnosing "lxmd is up
-    # but topology didn't converge" failures where the stderr/stdout ring
-    # buffer is discarded on success.
-    lxmd_logfile_path = os.environ.get("CONFORMANCE_LXMD_LOG")
-    lxmd_logfile = open(lxmd_logfile_path, "a") if lxmd_logfile_path else None
-    if lxmd_logfile:
-        lxmd_logfile.write(f"\n=== lxmd spawn (wire_handle={wire_handle}) ===\n")
-        lxmd_logfile.flush()
-
-    def _tail_lxmd():
-        try:
-            for line in lxmd_proc.stdout:
-                line = line.rstrip("\n")
-                recent_output.append(line)
+        def _tail_lxmd():
+            try:
+                for line in lxmd_proc.stdout:
+                    line = line.rstrip("\n")
+                    recent_output.append(line)
+                    if lxmd_logfile:
+                        lxmd_logfile.write(line + "\n")
+                        lxmd_logfile.flush()
+                    # Cap the buffer at ~200 lines so a long-running test
+                    # doesn't gradually eat memory. 200 lines is plenty
+                    # for "why did lxmd fail to start" diagnostics.
+                    if len(recent_output) > 200:
+                        del recent_output[:50]
+                    if prop_dest_hex[0] is None:
+                        m = _LXMD_PROP_DEST_RE.search(line)
+                        if m:
+                            prop_dest_hex[0] = m.group(1)
+                            started_event.set()
+            finally:
                 if lxmd_logfile:
-                    lxmd_logfile.write(line + "\n")
-                    lxmd_logfile.flush()
-                # Cap the buffer at ~200 lines so a long-running test
-                # doesn't gradually eat memory. 200 lines is plenty
-                # for "why did lxmd fail to start" diagnostics.
-                if len(recent_output) > 200:
-                    del recent_output[:50]
-                if prop_dest_hex[0] is None:
-                    m = _LXMD_PROP_DEST_RE.search(line)
-                    if m:
-                        prop_dest_hex[0] = m.group(1)
-                        started_event.set()
-        finally:
-            if lxmd_logfile:
-                try:
-                    lxmd_logfile.close()
-                except Exception:
-                    pass
-            reader_done.set()
+                    try:
+                        lxmd_logfile.close()
+                    except Exception:
+                        pass
+                reader_done.set()
 
-    # Thread start is the only place _tail_lxmd.finally runs, and that's
-    # the only place lxmd_logfile is closed. If Thread.start itself raises
-    # (OS thread-limit, memory pressure), _tail_lxmd never runs and the
-    # logfile leaks. Also handle lxmd_proc in the same guard so a thread-
-    # start failure doesn't leak the subprocess pipe either.
-    reader_thread = threading.Thread(
-        target=_tail_lxmd, name=f"lxmd-tail-{wire_handle}", daemon=True
-    )
-    try:
+        reader_thread = threading.Thread(
+            target=_tail_lxmd, name=f"lxmd-tail-{wire_handle}", daemon=True
+        )
         reader_thread.start()
     except Exception:
-        if lxmd_logfile:
+        # Reverse-unwind: file handle → subprocess → tempdir. Each step
+        # is idempotent on None so the guard works at any failure point.
+        if lxmd_logfile is not None:
             try:
                 lxmd_logfile.close()
             except Exception:
                 pass
-        _terminate_lxmd(lxmd_proc)
+        if lxmd_proc is not None:
+            _terminate_lxmd(lxmd_proc)
         _cleanup_lxmd_dir(lxmd_config_dir)
         raise
 
@@ -459,6 +465,21 @@ def cmd_lxmf_spawn_daemon_propagation_node(params):
         app_data = RNS.Identity.recall_app_data(prop_dest_bytes)
         if app_data:
             cfg = msgpack.unpackb(app_data)
+            # Schema reference (LXMF/LXMRouter.py get_propagation_node_app_data):
+            #   cfg[0] = legacy LXMF PN support (bool)
+            #   cfg[1] = node timebase (int epoch)
+            #   cfg[2] = propagation node state (bool)
+            #   cfg[3] = per-transfer limit (kB)
+            #   cfg[4] = per-sync limit
+            #   cfg[5] = [propagation_stamp_cost, flexibility, peering_cost]
+            #   cfg[6] = metadata dict
+            # cfg[5][0] is the advertised stamp cost. If LXMF changes this
+            # layout, the broad except below catches the resulting
+            # IndexError / TypeError and falls back to PROPAGATION_COST
+            # (16) — which remains the correct tests-default, but means a
+            # schema drift goes undetected rather than surfacing as an
+            # error. Re-audit against LXMRouter.get_propagation_node_app_data
+            # when bumping the pinned LXMF version.
             stamp_cost = int(cfg[5][0])
     except Exception:
         pass  # fall through to the default

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -72,9 +72,19 @@ def _wire_instance(wire_handle: str):
     Duplicates nothing — the wire_tcp module owns the RNS singleton;
     we just borrow its Reticulum to attach an LXMF router to.
     """
-    from wire_tcp import _instances as wire_instances, _instances_lock as wire_lock
+    wire_instances, wire_lock = _wire_lock_pair()
     with wire_lock:
         return wire_instances.get(wire_handle)
+
+
+def _wire_lock_pair():
+    """Return the (dict, lock) pair owned by wire_tcp so we can protect
+    reads/writes of the wire_inst dicts consistently with wire_tcp's
+    own discipline. Imported lazily so this module can load even if
+    wire_tcp isn't importable (e.g., minimal CI for a different layer).
+    """
+    from wire_tcp import _instances as wire_instances, _instances_lock as wire_lock
+    return wire_instances, wire_lock
 
 
 def cmd_lxmf_start(params):
@@ -447,7 +457,14 @@ def cmd_lxmf_spawn_daemon_propagation_node(params):
     # it. We attach to the wire handle (not an lxmf_start handle) because
     # the middle peer never calls lxmf_start — it has no LXMRouter of its
     # own; lxmd IS the router for this peer.
-    with _instances_lock:
+    #
+    # The wire_inst dict is owned by wire_tcp._instances and must be
+    # mutated under wire_tcp's own lock to stay consistent with how
+    # wire_tcp protects the same dict (see cmd_wire_* handlers). Using
+    # this module's _instances_lock here would not synchronize against
+    # wire_tcp's route-table and listener-accept threads.
+    _, wire_lock = _wire_lock_pair()
+    with wire_lock:
         wire_inst["lxmd_proc"] = lxmd_proc
         wire_inst["lxmd_config_dir"] = lxmd_config_dir
         wire_inst["lxmd_reader_thread"] = reader_thread
@@ -855,15 +872,22 @@ def cmd_lxmf_stop_daemon_propagation_node(params):
             none was present or it had already exited.
     """
     wire_handle = params["wire_handle"]
-    wire_inst = _wire_instance(wire_handle)
-    if wire_inst is None:
-        return {"stopped": False}
-
-    proc = wire_inst.pop("lxmd_proc", None)
-    lxmd_config_dir = wire_inst.pop("lxmd_config_dir", None)
-    reader_done = wire_inst.pop("lxmd_reader_done", None)
-    wire_inst.pop("lxmd_reader_thread", None)
-    wire_inst.pop("lxmd_recent_output", None)
+    # Look up and pop under wire_tcp's lock — the wire_inst dict is
+    # owned by wire_tcp and mutating it outside wire_lock races with
+    # wire_tcp's own accessors. We do the actual subprocess termination
+    # + reader-join OUTSIDE the lock because _terminate_lxmd blocks on
+    # wait() (up to 5s) and we don't want to hold a module-wide lock
+    # that long.
+    wire_instances, wire_lock = _wire_lock_pair()
+    with wire_lock:
+        wire_inst = wire_instances.get(wire_handle)
+        if wire_inst is None:
+            return {"stopped": False}
+        proc = wire_inst.pop("lxmd_proc", None)
+        lxmd_config_dir = wire_inst.pop("lxmd_config_dir", None)
+        reader_done = wire_inst.pop("lxmd_reader_done", None)
+        wire_inst.pop("lxmd_reader_thread", None)
+        wire_inst.pop("lxmd_recent_output", None)
 
     was_running = proc is not None and proc.poll() is None
     if proc is not None:

--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -1,0 +1,805 @@
+"""LXMF conformance commands (E2E propagation interop harness).
+
+Layered ON TOP of the wire_tcp layer. The pattern:
+
+  1. `wire_start_tcp_*` brings up a real RNS + TCP interface. For the
+     middle peer, wire_start_tcp_server is called with share_instance=True
+     so the RNS is published as an AF_UNIX shared instance.
+  2. `lxmf_start(wire_handle=...)` binds an LXMF router to the RNS instance
+     that wire_tcp already started. Sender/receiver use this for their
+     in-process LXMRouter.
+  3. Middle peer: `lxmf_spawn_daemon_propagation_node` spawns a real
+     `lxmd` subprocess that attaches to the shared RNS and runs the
+     propagation node. This matches how production deployments run
+     propagation nodes (see fleet/yggdrasil/reticulum-node.yaml).
+  4. Sender/receiver peers: `lxmf_set_outbound_propagation_node` points
+     them at lxmd's propagation destination.
+  5. Sender: `lxmf_send_propagated(recipient=receiver_delivery_hash, ...)`.
+  6. Receiver: `lxmf_sync_inbound()` pulls anything queued for it; then
+     `lxmf_poll_inbox()` drains what actually got delivered.
+
+The MVP scope is a single happy-path test (kotlin → lxmd → reference);
+these commands are symmetric so follow-up PRs can widen the parametrization
+matrix without bridge-surface changes.
+
+See the companion conformance-bridge/src/main/kotlin/Lxmf.kt for the Kotlin
+side. For the MVP, the Kotlin side only implements the sender commands
+(lxmf_start / lxmf_set_outbound_propagation_node / lxmf_send_propagated /
+lxmf_stop). `lxmf_spawn_daemon_propagation_node` is Python-only — Kotlin
+has no lxmd-equivalent daemon, so it's not on the Kotlin bridge at all.
+`lxmf_sync_inbound` and `lxmf_poll_inbox` throw NotImplementedError on
+Kotlin until a follow-up PR adds receiver-side parametrization.
+"""
+
+import os
+import re
+import secrets
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
+
+
+_instances = {}
+_instances_lock = threading.Lock()
+
+
+def _get_rns():
+    """Return the real (not stub) RNS module, matching wire_tcp.py.
+
+    We route through the bridge's full-RNS helper because earlier
+    crypto-only code paths install fake RNS modules that shadow the real
+    one; lxmf_bridge runs in the same process as those stubs.
+    """
+    from bridge_server import _get_full_rns
+    return _get_full_rns()
+
+
+def _get_lxmf():
+    """Return the LXMF top-level module.
+
+    Imported lazily so `--reference-only` bridge startup doesn't pay the
+    LXMF import cost for non-LXMF tests.
+    """
+    import LXMF
+    return LXMF
+
+
+def _wire_instance(wire_handle: str):
+    """Look up a wire_tcp bridge instance by its handle.
+
+    Duplicates nothing — the wire_tcp module owns the RNS singleton;
+    we just borrow its Reticulum to attach an LXMF router to.
+    """
+    from wire_tcp import _instances as wire_instances, _instances_lock as wire_lock
+    with wire_lock:
+        return wire_instances.get(wire_handle)
+
+
+def cmd_lxmf_start(params):
+    """Bring up an LXMF router bound to an already-started wire RNS peer.
+
+    params:
+        wire_handle (str): the handle returned by wire_start_tcp_server /
+            wire_start_tcp_client on this same bridge process. lxmf_start
+            attaches the LXMRouter to that same Reticulum instance (LXMF
+            needs a live Transport layer; it does not spin up its own).
+        display_name (str, optional): announced display name for the
+            delivery destination.
+
+    Returns:
+        handle (str): opaque handle for subsequent lxmf_* commands.
+        delivery_dest_hash (hex): the LXMF delivery destination hash.
+            This is what other peers address when sending messages to
+            this peer (what ends up in message.destination_hash).
+        identity_hash (hex): the LXMF router identity hash.
+    """
+    wire_handle = params["wire_handle"]
+    display_name = params.get("display_name")
+
+    wire_inst = _wire_instance(wire_handle)
+    if wire_inst is None:
+        raise ValueError(f"Unknown wire_handle: {wire_handle}")
+
+    RNS = _get_rns()
+    LXMF = _get_lxmf()
+
+    # Use a dedicated LXMF Identity (separate from the Transport identity),
+    # same pattern as production apps. The delivery destination is then
+    # announced on this identity's behalf.
+    identity = RNS.Identity()
+    storage_path = tempfile.mkdtemp(prefix="lxmf_conf_")
+
+    router = LXMF.LXMRouter(identity=identity, storagepath=storage_path)
+    delivery_destination = router.register_delivery_identity(
+        identity, display_name=display_name
+    )
+
+    # Per-instance inbox: messages delivered via the router's
+    # register_delivery_callback land here, and lxmf_poll_inbox drains
+    # this list atomically.
+    inbox = []
+    inbox_lock = threading.Lock()
+
+    def delivery_callback(message):
+        # Keep the serialized shape stable — downstream tests assert on
+        # exact key presence (== not in). See the tight-assertions feedback
+        # memo: loose membership/try-get has let duplicate-delivery and
+        # missing-field bugs slip past in the past.
+        entry = {
+            "hash": message.hash.hex() if getattr(message, "hash", None) else "",
+            "source": (
+                message.source_hash.hex()
+                if getattr(message, "source_hash", None)
+                else ""
+            ),
+            "destination": (
+                message.destination_hash.hex()
+                if getattr(message, "destination_hash", None)
+                else ""
+            ),
+            "title": (
+                message.title.decode("utf-8", errors="replace")
+                if isinstance(message.title, bytes)
+                else (message.title or "")
+            ),
+            "content": (
+                message.content.decode("utf-8", errors="replace")
+                if isinstance(message.content, bytes)
+                else (message.content or "")
+            ),
+        }
+        # Fields are opaque bytes/values; serialize them as hex for bytes
+        # and keep primitives as-is so tests can assert on them directly.
+        fields = {}
+        for k, v in (getattr(message, "fields", None) or {}).items():
+            fields[str(k)] = v.hex() if isinstance(v, bytes) else v
+        entry["fields"] = fields
+        with inbox_lock:
+            inbox.append(entry)
+
+    router.register_delivery_callback(delivery_callback)
+
+    handle = secrets.token_hex(8)
+    with _instances_lock:
+        _instances[handle] = {
+            "wire_handle": wire_handle,
+            "router": router,
+            "identity": identity,
+            "delivery_destination": delivery_destination,
+            "storage_path": storage_path,
+            "inbox": inbox,
+            "inbox_lock": inbox_lock,
+            "propagation_enabled": False,
+        }
+
+    # Announce the delivery destination so the other peers can route to it.
+    delivery_destination.announce()
+
+    return {
+        "handle": handle,
+        "delivery_dest_hash": delivery_destination.hash.hex(),
+        "identity_hash": identity.hash.hex(),
+    }
+
+
+# Matches the "LXMF Propagation Node started on <hex>" line lxmd logs once
+# the propagation destination is live. `prettyhexrep` wraps the hex in
+# angle brackets, e.g. "<abcdef1234567890>" — 20 hex chars for the
+# TRUNCATED_HASHLENGTH=10 default. Regex kept tight (exactly that prefix
+# + angle-bracketed hex) to avoid matching unrelated log lines.
+_LXMD_PROP_DEST_RE = re.compile(
+    r"LXMF Propagation Node started on <([0-9a-f]+)>"
+)
+
+
+def cmd_lxmf_spawn_daemon_propagation_node(params):
+    """Spawn a real lxmd subprocess as this peer's propagation node.
+
+    Architecture: the middle peer's wire_start_tcp_server call must have
+    set share_instance=True. That publishes the RNS as an AF_UNIX shared
+    instance. This command:
+
+      1. Writes an lxmd config file with [propagation] enable_node=yes,
+         pointing at the same rnsconfig dir the wire bridge created.
+      2. Spawns `lxmd --rnsconfig <rns_config_dir> --config <lxmd_dir>
+         --propagation-node -v`. We drop -s (service mode) so stdout/
+         stderr are capturable for debugging.
+      3. Tails stdout until lxmd logs "LXMF Propagation Node started on
+         <hex>" — that's the propagation destination the sender/receiver
+         need to target.
+      4. Stores the Popen handle on the peer's state so lxmf_stop
+         can terminate it cleanly.
+
+    Matches how production deployments run lxmd (see
+    fleet/yggdrasil/reticulum-node.yaml) rather than flipping an
+    in-process LXMRouter into propagation-node mode. The in-process path
+    is a test-harness hack that doesn't exercise the real
+    separate-process, shared-instance code path, which is what actual
+    deployments hit.
+
+    params:
+        wire_handle (str): the wire bridge handle for the middle peer.
+            Must have been created with share_instance=True.
+        display_name (str, optional): lxmd config display_name. Defaults
+            to "conformance-prop-node".
+        startup_timeout_sec (float, optional): how long to wait for lxmd
+            to log "Propagation Node started" before giving up. Defaults
+            to 30s — lxmd at stamp_cost_target=13 (the minimum enforced
+            by LXMRouter.PROPAGATION_COST_MIN) typically takes <5s to
+            start, but first-launch subsystem init (storage, ratchets,
+            identity generation) can push past 10s on slow CI runners.
+
+    Returns:
+        propagation_node_dest_hash (hex): lxmd's propagation destination
+            hash, to be passed to sender/receiver
+            lxmf_set_outbound_propagation_node calls.
+        stamp_cost (int): the actual stamp cost lxmd will require
+            (floor is PROPAGATION_COST_MIN=13; a lower value in the
+            config is clamped up by LXMF itself).
+
+    Raises:
+        FileNotFoundError: if `lxmd` is not on PATH.
+        RuntimeError: if lxmd exits before emitting the propagation
+            destination line, or if the timeout elapses without the
+            line being logged.
+        ValueError: if the wire handle is unknown or its RNS wasn't
+            started with share_instance=True (lxmd would spin up its
+            own competing Reticulum otherwise, fragmenting the network).
+    """
+    wire_handle = params["wire_handle"]
+    display_name = params.get("display_name") or "conformance-prop-node"
+    startup_timeout_sec = float(params.get("startup_timeout_sec", 30.0))
+
+    # Verify lxmd is installed up front so the failure mode is
+    # FileNotFoundError at fixture time rather than a mysterious hang.
+    lxmd_path = shutil.which("lxmd")
+    if not lxmd_path:
+        raise FileNotFoundError(
+            "lxmd binary not found on PATH. Install with `pip install lxmf` "
+            "(the LXMF package ships lxmd as a console_script entrypoint)."
+        )
+
+    wire_inst = _wire_instance(wire_handle)
+    if wire_inst is None:
+        raise ValueError(f"Unknown wire_handle: {wire_handle}")
+
+    if not wire_inst.get("share_instance"):
+        raise ValueError(
+            f"wire_handle {wire_handle} was not started with share_instance=True. "
+            f"lxmd needs to attach to a shared RNS instance; otherwise it "
+            f"would spawn its own Reticulum and the three-peer topology "
+            f"wouldn't converge."
+        )
+
+    rns_config_dir = wire_inst["config_dir"]
+
+    # Write the lxmd config. Shape mirrors the production
+    # fleet/yggdrasil/lxmf-config.yaml ConfigMap. Key choices:
+    #   - announce_at_start = Yes: emit the propagation announce
+    #     immediately so sender/receiver can resolve the node without
+    #     waiting for the periodic announce timer.
+    #   - announce_interval omitted for node: we only need the startup
+    #     announce for the MVP test window (~60s).
+    #   - message_storage_limit=100: cap store size; fixture is ephemeral
+    #     so this is belt-and-suspenders.
+    #   - propagation_stamp_cost_target not set: defaults to
+    #     PROPAGATION_COST (16); we use it as-is. LXMF-kt's sender reads
+    #     the cost from the node's announce and generates a matching
+    #     stamp. At cost=16 that's ~65k attempts (~2-5s) — acceptable.
+    lxmd_config_dir = tempfile.mkdtemp(prefix="lxmd_conf_")
+    lxmd_config_path = os.path.join(lxmd_config_dir, "config")
+    # CONFORMANCE_LXMD_LOGLEVEL overrides the default loglevel (4=Notice).
+    # Set to 7 (EXTREME) when debugging announce forwarding / path convergence
+    # issues — matches RNS.LOG_EXTREME and surfaces the "Sending announce"
+    # lines lxmd emits at that level.
+    lxmd_loglevel = int(os.environ.get("CONFORMANCE_LXMD_LOGLEVEL", "4"))
+    with open(lxmd_config_path, "w") as f:
+        f.write(
+            "[lxmf]\n"
+            f"  display_name = {display_name}\n"
+            "  announce_at_start = Yes\n"
+            "\n"
+            "[logging]\n"
+            f"  loglevel = {lxmd_loglevel}\n"
+            "\n"
+            "[propagation]\n"
+            "  enable_node = Yes\n"
+            f"  node_name = {display_name}\n"
+            "  announce_at_start = Yes\n"
+            "  message_storage_limit = 100\n"
+            "  propagation_message_max_accepted_size = 25000\n"
+            "  propagation_sync_max_accepted_size = 102400\n"
+        )
+
+    # Spawn lxmd. Drop -s so stdout/stderr are text streams we can tail.
+    # --propagation-node is redundant with enable_node=Yes in the config
+    # but matches the production invocation and is belt-and-suspenders.
+    #
+    # PYTHONUNBUFFERED=1 is essential: when stdout is piped (not a tty),
+    # CPython buffers full blocks, which means the "Propagation Node
+    # started on <hex>" line won't reach our reader until lxmd emits
+    # several more log lines — and in practice lxmd goes quiet after
+    # startup, so without this we hit the 30s timeout even though lxmd
+    # is healthy. `text=True, bufsize=1` alone doesn't fix this because
+    # bufsize controls OUR pipe, not the child's internal stdio buffer.
+    child_env = dict(os.environ)
+    child_env["PYTHONUNBUFFERED"] = "1"
+    lxmd_proc = subprocess.Popen(
+        [
+            lxmd_path,
+            "--rnsconfig", rns_config_dir,
+            "--config", lxmd_config_dir,
+            "--propagation-node",
+            "-v",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,  # interleaved so the regex match wins
+        text=True,
+        bufsize=1,  # line-buffered on OUR pipe
+        env=child_env,
+    )
+
+    # Drain lxmd's stdout in a background thread so its pipe buffer can't
+    # fill and deadlock the child. We only actually care about the
+    # "Propagation Node started on <hex>" line; everything else is tee'd
+    # into a ring buffer for teardown-time diagnostics.
+    recent_output: list[str] = []
+    prop_dest_hex = [None]  # captured by the thread; single-slot mailbox
+    started_event = threading.Event()
+    reader_done = threading.Event()
+
+    # Optional file-tee for debugging: if CONFORMANCE_LXMD_LOG is set, we
+    # also mirror lxmd's output there. Useful for diagnosing "lxmd is up
+    # but topology didn't converge" failures where the stderr/stdout ring
+    # buffer is discarded on success.
+    lxmd_logfile_path = os.environ.get("CONFORMANCE_LXMD_LOG")
+    lxmd_logfile = open(lxmd_logfile_path, "a") if lxmd_logfile_path else None
+    if lxmd_logfile:
+        lxmd_logfile.write(f"\n=== lxmd spawn (wire_handle={wire_handle}) ===\n")
+        lxmd_logfile.flush()
+
+    def _tail_lxmd():
+        try:
+            for line in lxmd_proc.stdout:
+                line = line.rstrip("\n")
+                recent_output.append(line)
+                if lxmd_logfile:
+                    lxmd_logfile.write(line + "\n")
+                    lxmd_logfile.flush()
+                # Cap the buffer at ~200 lines so a long-running test
+                # doesn't gradually eat memory. 200 lines is plenty
+                # for "why did lxmd fail to start" diagnostics.
+                if len(recent_output) > 200:
+                    del recent_output[:50]
+                if prop_dest_hex[0] is None:
+                    m = _LXMD_PROP_DEST_RE.search(line)
+                    if m:
+                        prop_dest_hex[0] = m.group(1)
+                        started_event.set()
+        finally:
+            if lxmd_logfile:
+                try:
+                    lxmd_logfile.close()
+                except Exception:
+                    pass
+            reader_done.set()
+
+    reader_thread = threading.Thread(
+        target=_tail_lxmd, name=f"lxmd-tail-{wire_handle}", daemon=True
+    )
+    reader_thread.start()
+
+    # Wait for the startup line, the process exiting early, or timeout.
+    deadline = time.time() + startup_timeout_sec
+    while time.time() < deadline:
+        if started_event.wait(timeout=0.25):
+            break
+        # If lxmd died without emitting the line, fail fast rather than
+        # running the timeout clock to zero.
+        if lxmd_proc.poll() is not None:
+            reader_done.wait(timeout=1.0)
+            tail = "\n".join(recent_output[-50:])
+            _cleanup_lxmd_dir(lxmd_config_dir)
+            raise RuntimeError(
+                f"lxmd exited with code {lxmd_proc.returncode} before "
+                f"emitting the propagation-node-started line.\n"
+                f"Last lxmd output:\n{tail}"
+            )
+
+    if prop_dest_hex[0] is None:
+        # Timeout. Kill lxmd so we don't leak it.
+        _terminate_lxmd(lxmd_proc)
+        reader_done.wait(timeout=1.0)
+        tail = "\n".join(recent_output[-50:])
+        _cleanup_lxmd_dir(lxmd_config_dir)
+        raise RuntimeError(
+            f"lxmd did not log 'LXMF Propagation Node started on <hex>' "
+            f"within {startup_timeout_sec:.1f}s.\n"
+            f"Last lxmd output:\n{tail}"
+        )
+
+    prop_dest_bytes = bytes.fromhex(prop_dest_hex[0])
+
+    # Park the subprocess on the wire instance's state so teardown reaches
+    # it. We attach to the wire handle (not an lxmf_start handle) because
+    # the middle peer never calls lxmf_start — it has no LXMRouter of its
+    # own; lxmd IS the router for this peer.
+    with _instances_lock:
+        wire_inst["lxmd_proc"] = lxmd_proc
+        wire_inst["lxmd_config_dir"] = lxmd_config_dir
+        wire_inst["lxmd_reader_thread"] = reader_thread
+        wire_inst["lxmd_reader_done"] = reader_done
+        wire_inst["lxmd_recent_output"] = recent_output
+
+    # Stamp cost: query lxmd's effective value via the announce app_data
+    # so tests can log what was actually used. Best-effort — if the
+    # announce hasn't propagated to our RNS yet, fall back to the config
+    # value (LXMF's MIN floor makes the actual value >= 13).
+    RNS = _get_rns()
+    stamp_cost = 16  # LXMRouter.PROPAGATION_COST default
+    try:
+        import msgpack
+        app_data = RNS.Identity.recall_app_data(prop_dest_bytes)
+        if app_data:
+            cfg = msgpack.unpackb(app_data)
+            stamp_cost = int(cfg[5][0])
+    except Exception:
+        pass  # fall through to the default
+
+    return {
+        "propagation_node_dest_hash": prop_dest_hex[0],
+        "stamp_cost": stamp_cost,
+        # Expose the on-disk storage dir so the fixture can assert on
+        # the propagation node's stored-message count directly (via
+        # filesystem glob) rather than routing a count query through
+        # the bridge. Path derivation (verified empirically — the
+        # extra "/lxmf" is added by LXMRouter internally, not lxmd):
+        #   lxmd.py:     storagedir   = configdir + "/storage"
+        #   lxmd.py:     LXMRouter(storagepath=storagedir)
+        #   LXMRouter:   self.storagepath  = storagepath + "/lxmf"
+        #   LXMRouter:   self.messagepath  = self.storagepath + "/messagestore"
+        # Net result: messages land at <configdir>/storage/lxmf/messagestore.
+        # See LXMF/LXMRouter.py lines 121 + 535; LXMF/Utilities/lxmd.py line 319.
+        "lxmd_config_dir": lxmd_config_dir,
+        "messagestore_dir": os.path.join(
+            lxmd_config_dir, "storage", "lxmf", "messagestore"
+        ),
+    }
+
+
+def _terminate_lxmd(proc: subprocess.Popen, timeout_sec: float = 5.0):
+    """SIGTERM lxmd, wait, SIGKILL fallback. Idempotent on already-exited
+    processes."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=timeout_sec)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=timeout_sec)
+    except Exception:
+        # Best-effort teardown; a lingering lxmd across test runs is
+        # annoying but not catastrophic (the abstract socket namespace
+        # clears when the shared-instance server dies).
+        pass
+
+
+def _cleanup_lxmd_dir(lxmd_config_dir: str):
+    """Remove lxmd's config + storage tempdir. Idempotent."""
+    if lxmd_config_dir and os.path.isdir(lxmd_config_dir):
+        shutil.rmtree(lxmd_config_dir, ignore_errors=True)
+
+
+def cmd_lxmf_set_outbound_propagation_node(params):
+    """Point this peer's LXMRouter at a remote propagation node.
+
+    The peer must already have a path + identity for the propagation
+    destination (either via a received announce or an explicit
+    Identity.recall). Assertion on the presence of the path is deferred
+    to the caller — if this bridge doesn't yet know the propagation
+    node, LXMF will still set the hash and fail later when it tries to
+    open a link.
+
+    params:
+        handle (str): lxmf_start handle.
+        propagation_node_dest_hash (hex): the value returned by the
+            other peer's lxmf_enable_propagation_node.
+
+    Returns:
+        success (bool)
+    """
+    handle = params["handle"]
+    pn_hash_hex = params["propagation_node_dest_hash"]
+    pn_hash = bytes.fromhex(pn_hash_hex)
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    router = inst["router"]
+    router.set_outbound_propagation_node(pn_hash)
+
+    return {"success": True}
+
+
+def cmd_lxmf_send_propagated(params):
+    """Build + submit an LXMessage with PROPAGATED delivery.
+
+    Requires the recipient's identity to be recallable (i.e. a delivery
+    announce from the recipient has been observed on this peer's RNS
+    instance). The caller is responsible for sequencing the announces.
+
+    params:
+        handle (str): lxmf_start handle for the sender.
+        recipient_delivery_dest_hash (hex): recipient's delivery hash,
+            as returned by the recipient's lxmf_start.
+        content (str): UTF-8 message content.
+        title (str, optional): UTF-8 title, defaults to "".
+        fields (dict, optional): string-keyed int fields mapped to
+            hex-encoded values (same convention as the LXMF send_direct
+            command already in the bridge). Deferred for MVP — tests
+            only use (content, title).
+
+    Returns:
+        message_hash (hex): LXMessage hash.
+    """
+    handle = params["handle"]
+    recipient_hash_hex = params["recipient_delivery_dest_hash"]
+    content = params["content"]
+    title = params.get("title", "")
+
+    recipient_hash = bytes.fromhex(recipient_hash_hex)
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    RNS = _get_rns()
+    LXMF = _get_lxmf()
+
+    # Rely on the recipient's delivery announce already having been
+    # observed — this is the sequencing the lxmf_3peer fixture enforces.
+    # If it hasn't, recall returns None and we surface that as an
+    # explicit error rather than letting LXMF silently fail downstream
+    # (which would show up as "message sent, never arrives" and is
+    # exactly the class of bug loose assertions have let slip).
+    recipient_identity = RNS.Identity.recall(recipient_hash)
+    if recipient_identity is None:
+        raise RuntimeError(
+            f"No identity known for recipient {recipient_hash.hex()}. "
+            f"Ensure the recipient announced its delivery destination "
+            f"before calling lxmf_send_propagated."
+        )
+
+    recipient_destination = RNS.Destination(
+        recipient_identity,
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+
+    message = LXMF.LXMessage(
+        destination=recipient_destination,
+        source=inst["delivery_destination"],
+        content=content,
+        title=title,
+        desired_method=LXMF.LXMessage.PROPAGATED,
+    )
+
+    router = inst["router"]
+
+    # LXMessage defaults BOTH defer_stamp and defer_propagation_stamp to
+    # True (see LXMF/LXMessage.py lines 170-171). For PROPAGATED delivery
+    # with defer_propagation_stamp=True, handle_outbound parks the
+    # message in pending_deferred_stamps and relies on the jobloop to
+    # process it. In practice, the deferred-stamp jobloop is designed
+    # for interactive app usage and does NOT reliably fire within the
+    # ~30s window of a tight conformance test — reference→lxmd→receiver
+    # silently loses the message because the stamp never gets generated
+    # in time.
+    #
+    # Do the stamp generation synchronously here so handle_outbound hits
+    # the non-deferred path (line 1673 of LXMRouter.py). The stamp is
+    # attached via the LXMessage.propagation_stamp field. After that,
+    # toggle BOTH defer flags off so the outbound-processing conditional
+    # doesn't re-deflect us back to pending_deferred_stamps.
+    #
+    # Kotlin's LXMF-kt sender already does the equivalent — its
+    # handleOutbound path generates the propagation stamp synchronously
+    # before handing off to the link layer.
+    target_cost = router.get_outbound_propagation_cost()
+    if target_cost is None:
+        raise RuntimeError(
+            "Could not resolve propagation node stamp cost. The "
+            "propagation node's announce app_data is not cached on "
+            "this peer's RNS — ensure the fixture's path-convergence "
+            "guards succeeded before calling lxmf_send_propagated."
+        )
+    generated_stamp = message.get_propagation_stamp(target_cost=target_cost)
+    if generated_stamp is None:
+        raise RuntimeError(
+            f"Failed to generate propagation stamp for {message.transient_id!r} "
+            f"at cost {target_cost}. LXStamper.generate_stamp returned None."
+        )
+    message.propagation_stamp = generated_stamp
+    message.propagation_stamp_valid = True
+    message.defer_stamp = False
+    message.defer_propagation_stamp = False
+    # pack() must be re-run after the stamp is attached (LXMessage.pack
+    # bundles the stamp into the outbound payload). Clear `packed` so
+    # handle_outbound's `if not lxmessage.packed: lxmessage.pack()`
+    # regenerates the wire-format blob.
+    message.packed = None
+
+    router.handle_outbound(message)
+
+    return {
+        "message_hash": message.hash.hex() if message.hash else "",
+    }
+
+
+def cmd_lxmf_sync_inbound(params):
+    """Ask this peer's LXMRouter to fetch stored messages from its
+    configured outbound propagation node.
+
+    Blocks until the transfer finishes (COMPLETE / FAILED / timeout).
+    Returns the number of messages retrieved — NOT necessarily delivered
+    to the callback yet. Callers should follow with lxmf_poll_inbox to
+    actually drain the delivered messages.
+
+    params:
+        handle (str): lxmf_start handle.
+        timeout_ms (int, optional): deadline for the transfer state to
+            leave LINK_ESTABLISHED / REQUESTING_MESSAGES. Defaults to
+            30s to match RNS's default link RTT budget.
+
+    Returns:
+        messages_received (int): propagation_transfer_last_result.
+        state (str): final propagation_transfer_state name.
+    """
+    handle = params["handle"]
+    timeout_ms = int(params.get("timeout_ms", 30000))
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    LXMF = _get_lxmf()
+    router = inst["router"]
+    router.request_messages_from_propagation_node(inst["identity"])
+
+    # Wait for the transfer state machine to settle into a terminal state.
+    # Python LXMF's state names are prefixed PR_* as module-level ints.
+    terminal_states = {
+        LXMF.LXMRouter.PR_COMPLETE,
+        LXMF.LXMRouter.PR_FAILED,
+        LXMF.LXMRouter.PR_NO_IDENTITY_RCVD,
+        LXMF.LXMRouter.PR_NO_ACCESS,
+    }
+    deadline = time.time() + (timeout_ms / 1000.0)
+    while time.time() < deadline:
+        state = router.propagation_transfer_state
+        if state in terminal_states:
+            break
+        time.sleep(0.1)
+
+    final_state = router.propagation_transfer_state
+    last_result = int(router.propagation_transfer_last_result or 0)
+
+    # Let any freshly-decrypted messages hit the delivery callback before
+    # we return — callbacks run on the router's own threads and the caller
+    # is about to poll the inbox.
+    time.sleep(0.3)
+
+    return {
+        "messages_received": last_result,
+        "state": str(final_state),
+    }
+
+
+def cmd_lxmf_poll_inbox(params):
+    """Drain delivered LXMessages accumulated by the delivery callback.
+
+    The inbox holds everything the router has successfully decrypted and
+    delivered since lxmf_start (or the last poll). Draining is atomic
+    — tests that want exact-count semantics can call this once and
+    assert on the length directly (mirrors wire_link_poll).
+
+    params:
+        handle (str): lxmf_start handle.
+
+    Returns:
+        messages (list[dict]): each with hash, source, destination,
+            title, content, fields. Fields values are hex-encoded if
+            bytes, passthrough otherwise.
+    """
+    handle = params["handle"]
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    with inst["inbox_lock"]:
+        drained = list(inst["inbox"])
+        inst["inbox"].clear()
+
+    return {"messages": drained}
+
+
+def cmd_lxmf_stop(params):
+    """Tear down an LXMF router instance.
+
+    Does NOT stop the underlying wire RNS singleton (wire_stop handles
+    that). Safe to call multiple times.
+    """
+    handle = params["handle"]
+    with _instances_lock:
+        inst = _instances.pop(handle, None)
+    if inst is None:
+        return {"stopped": False}
+
+    # LXMRouter doesn't expose a clean stop() API on the Python side;
+    # the router's background threads are daemons and will die with the
+    # process. We just clean up our own bookkeeping here.
+    storage_path = inst.get("storage_path")
+    if storage_path and os.path.isdir(storage_path):
+        import shutil
+        shutil.rmtree(storage_path, ignore_errors=True)
+
+    return {"stopped": True}
+
+
+def cmd_lxmf_stop_daemon_propagation_node(params):
+    """Terminate the lxmd subprocess started for this wire handle.
+
+    Idempotent — safe to call if no daemon was ever started (returns
+    stopped=False) or if the daemon already exited. The fixture calls
+    this in teardown to guarantee no lxmd lingers across test runs.
+
+    params:
+        wire_handle (str): the wire handle that owns the lxmd subprocess.
+
+    Returns:
+        stopped (bool): True if a running lxmd was terminated, False if
+            none was present or it had already exited.
+    """
+    wire_handle = params["wire_handle"]
+    wire_inst = _wire_instance(wire_handle)
+    if wire_inst is None:
+        return {"stopped": False}
+
+    proc = wire_inst.pop("lxmd_proc", None)
+    lxmd_config_dir = wire_inst.pop("lxmd_config_dir", None)
+    reader_done = wire_inst.pop("lxmd_reader_done", None)
+    wire_inst.pop("lxmd_reader_thread", None)
+    wire_inst.pop("lxmd_recent_output", None)
+
+    was_running = proc is not None and proc.poll() is None
+    if proc is not None:
+        _terminate_lxmd(proc)
+    if reader_done is not None:
+        reader_done.wait(timeout=2.0)
+    _cleanup_lxmd_dir(lxmd_config_dir)
+
+    return {"stopped": was_running}
+
+
+LXMF_COMMANDS = {
+    "lxmf_start": cmd_lxmf_start,
+    "lxmf_spawn_daemon_propagation_node": cmd_lxmf_spawn_daemon_propagation_node,
+    "lxmf_stop_daemon_propagation_node": cmd_lxmf_stop_daemon_propagation_node,
+    "lxmf_set_outbound_propagation_node": cmd_lxmf_set_outbound_propagation_node,
+    "lxmf_send_propagated": cmd_lxmf_send_propagated,
+    "lxmf_sync_inbound": cmd_lxmf_sync_inbound,
+    "lxmf_poll_inbox": cmd_lxmf_poll_inbox,
+    "lxmf_stop": cmd_lxmf_stop,
+}

--- a/reference/wire_tcp.py
+++ b/reference/wire_tcp.py
@@ -76,12 +76,22 @@ def _write_ifac_ini(
     iface_block: str,
     network_name: str,
     passphrase: str,
+    share_instance: bool = False,
+    instance_name: str | None = None,
 ):
     """Write a minimal RNS config with a single interface.
 
     `iface_block` is the full interface type/target/port block; this helper
     adds the `[reticulum]` header, the shared IFAC fields (if any), and
     wraps the interface block.
+
+    share_instance=True publishes this RNS as a shared instance (AF_UNIX
+    abstract socket) so out-of-process daemons like lxmd can attach via
+    `--rnsconfig <config_dir>` and ride this peer's Transport. Used by the
+    LXMF propagation-node peer so the daemon isn't a standalone Reticulum.
+    When True, instance_name MUST be set to a value unique to this bridge
+    process — the abstract socket namespace is global and default=="default"
+    collides across parallel bridges.
     """
     os.makedirs(config_dir, exist_ok=True)
     config_file = os.path.join(config_dir, "config")
@@ -92,11 +102,23 @@ def _write_ifac_ini(
     if passphrase:
         ifac_lines += f"    passphrase = {passphrase}\n"
 
+    if share_instance and not instance_name:
+        raise ValueError(
+            "share_instance=True requires instance_name; leaving it at the "
+            "default 'default' would collide with parallel bridge processes."
+        )
+
+    share_value = "Yes" if share_instance else "No"
+    instance_line = (
+        f"  instance_name = {instance_name}\n" if share_instance and instance_name else ""
+    )
+
     with open(config_file, "w") as f:
         f.write(
             "[reticulum]\n"
             "  enable_transport = Yes\n"
-            "  share_instance = No\n"
+            f"  share_instance = {share_value}\n"
+            f"{instance_line}"
             "  respond_to_probes = No\n"
             "\n"
             "[interfaces]\n"
@@ -126,10 +148,16 @@ def _ensure_wire_rns_started(config_dir: str):
         return _shared_wire_rns
 
     _shared_wire_config_dir = config_dir
-    RNS.loglevel = RNS.LOG_CRITICAL
+    # Default loglevel=CRITICAL keeps the bridge's stderr clean. Setting
+    # CONFORMANCE_WIRE_DEBUG=1 bumps it to DEBUG, useful when tracking
+    # down "topology didn't converge" style issues (are announces even
+    # being forwarded?). Opt-in so the vast majority of tests stay quiet.
+    debug_wire = bool(os.environ.get("CONFORMANCE_WIRE_DEBUG"))
+    ll = RNS.LOG_DEBUG if debug_wire else RNS.LOG_CRITICAL
+    RNS.loglevel = ll
     _shared_wire_rns = RNS.Reticulum(
         configdir=config_dir,
-        loglevel=RNS.LOG_CRITICAL,
+        loglevel=ll,
     )
     return _shared_wire_rns
 
@@ -140,15 +168,28 @@ def cmd_wire_start_tcp_server(params):
     If bind_port=0 (default), pre-allocates a free port OS-side so both
     impls can use the same "tell me a usable port" contract. The
     returned `port` is what the client peer should connect to.
+
+    share_instance (bool, default False): publish this RNS as an AF_UNIX
+    shared instance so external daemons (lxmd) can attach via `--rnsconfig
+    <config_dir>` rather than spinning up their own Reticulum. Only the
+    middle peer in the LXMF propagation trio needs this — sender/receiver
+    run their LXMRouters in-process against the bridge's own Reticulum.
+    When True, a unique `instance_name` is auto-generated from the token
+    so parallel bridge subprocesses don't collide on the abstract socket.
     """
     network_name = params.get("network_name") or ""
     passphrase = params.get("passphrase") or ""
     bind_port = int(params.get("bind_port", 0))
+    share_instance = bool(params.get("share_instance", False))
 
     if bind_port == 0:
         bind_port = _allocate_free_port()
 
     config_dir = tempfile.mkdtemp(prefix="rns_wire_server_")
+    # instance_name must be unique per bridge process: the AF_UNIX abstract
+    # namespace (\0rns/<name>) is global. Use the tail of the config dir
+    # so it's stable within this process but distinct across parallel ones.
+    instance_name = f"wire_{os.path.basename(config_dir)}"
     iface_block = (
         "    type = TCPServerInterface\n"
         "    enabled = Yes\n"
@@ -161,6 +202,8 @@ def cmd_wire_start_tcp_server(params):
         iface_block,
         network_name,
         passphrase,
+        share_instance=share_instance,
+        instance_name=instance_name if share_instance else None,
     )
 
     RNS = _get_rns()
@@ -176,6 +219,8 @@ def cmd_wire_start_tcp_server(params):
             "role": "server",
             "port": bind_port,
             "destinations": [],
+            "share_instance": share_instance,
+            "instance_name": instance_name if share_instance else None,
         }
 
     return {

--- a/tests/lxmf/conftest.py
+++ b/tests/lxmf/conftest.py
@@ -26,7 +26,6 @@ See reference/lxmf_bridge.py and conformance-bridge/src/main/kotlin/
 Lxmf.kt for the command surface these fixtures drive.
 """
 
-import glob
 import os
 import secrets
 import shutil

--- a/tests/lxmf/conftest.py
+++ b/tests/lxmf/conftest.py
@@ -1,0 +1,529 @@
+"""LXMF-layer (propagation E2E) fixtures.
+
+Layered on top of tests/wire/. The wire layer spins up a real Reticulum +
+TCP interface per bridge; the LXMF layer attaches an LXMRouter to that
+same RNS instance and exercises PROPAGATED delivery across three peers:
+
+    sender (TCPClient)                    receiver (TCPClient)
+           \\                                   /
+            `----> transport (TCPServer) <----'
+                   enable_transport=True
+                   share_instance=True
+                       └── lxmd subprocess (propagation node)
+
+The middle peer wears two hats: its bridge process is the RNS TCP
+transport, and a SEPARATE `lxmd` subprocess attached to the same shared
+Reticulum is the LXMF propagation node. This matches how production
+deployments run propagation nodes (see fleet/yggdrasil/reticulum-node.yaml
+— rnsd + lxmd in the same container, sharing `/root/.reticulum`).
+
+MVP emits a single parametrization: (kotlin, lxmd, reference). The middle
+slot is "lxmd" (not "reference") to make it architecturally explicit that
+it's a separate daemon process, not an in-router mode. If LXMF-kt ever
+grows a daemon equivalent, the slot could become "lxmd-kt".
+
+See reference/lxmf_bridge.py and conformance-bridge/src/main/kotlin/
+Lxmf.kt for the command surface these fixtures drive.
+"""
+
+import glob
+import os
+import secrets
+import shutil
+import time
+
+import pytest
+
+from bridge_client import BridgeClient
+from conftest import BRIDGE_COMMANDS, ROOT_DIR, get_impl_list, resolve_command
+
+# Reuse the wire-layer machinery: the LXMF layer sits on top of a real
+# wire-level Reticulum and doesn't need to re-implement start_tcp_* /
+# poll_path. These symbols live in tests/wire/conftest.py; pytest has
+# already inserted the tests/ dir into sys.path for the rootdir
+# conftest.py pattern, but the wire conftest is in a subpackage so we
+# import it by package path.
+from tests.wire.conftest import _WirePeer, _env_for
+
+
+def _resolve_command_for_trio(impl: str) -> str:
+    """Resolve the bridge command for an LXMF trio peer.
+
+    Why this exists: the root conftest's resolve_command honors the
+    CONFORMANCE_BRIDGE_CMD env var globally — it returns that command
+    for EVERY impl name, including "reference". That's fine for the
+    wire-layer tests (they test interop by mis-labeling — a
+    "reference-to-kotlin" pair just runs kotlin twice when the env
+    override is the kotlin bridge), but it breaks the LXMF fixture,
+    which needs the reference Python bridge for the propagation_node
+    slot regardless of which impl is on sender/receiver.
+
+    Resolution rules:
+      - If impl == "kotlin" (the SUT), honor CONFORMANCE_BRIDGE_CMD via
+        resolve_command — this is how CI points at a freshly-built
+        shadowJar. Same mechanism works for the sender-kotlin and the
+        receiver-kotlin slots independently.
+      - If impl == "reference" or "lxmd", bypass the env override and
+        use BRIDGE_COMMANDS["reference"] directly. This lets a run with
+        CONFORMANCE_BRIDGE_CMD=<kotlin jar> still exercise reference-on-
+        reference sanity combos with a real Python bridge driving lxmd.
+    """
+    if impl == "kotlin":
+        return resolve_command(impl)
+    if impl in ("reference", "lxmd"):
+        return BRIDGE_COMMANDS["reference"].format(root=ROOT_DIR)
+    if impl not in BRIDGE_COMMANDS:
+        raise ValueError(f"Unknown implementation: {impl}")
+    return BRIDGE_COMMANDS[impl].format(root=ROOT_DIR)
+
+
+# Settle times — propagation requires announces to traverse the TCP hop
+# and be processed by Transport on all three peers. These are measured
+# empirically against the Python reference impl; tighten if they start
+# holding CI back, but don't loosen in the trio assertions (we want
+# tight assertions to actually flip red on regressions, per the
+# tight-assertions feedback doc).
+_SETTLE_SEC = 2.0
+_ANNOUNCE_PROPAGATION_SEC = 5.0
+_INTER_ANNOUNCE_STAGGER_SEC = 3.0
+_SYNC_TIMEOUT_MS = 30_000
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize LXMF tests over (sender_impl, prop_node_impl, receiver_impl).
+
+    The middle slot is always "lxmd" — architecturally a Python subprocess
+    running the real lxmd daemon (not an in-router-mode LXMRouter). The
+    tuple shape is kept future-proof: if LXMF-kt ever ships a daemon, the
+    middle could become "lxmd-kt". Today, "lxmd" is the only value that
+    makes sense for a separate-process propagation node.
+
+    Cartesian product over impls ∪ {"reference"} for sender + receiver:
+    with --impl=kotlin this emits 4 combos (reference and kotlin on each
+    end). Mirrors the wire-layer `_parametrize_wire_trio` pattern so the
+    matrix shape is consistent across test categories.
+
+    The reference-only combo is the end-to-end sanity baseline (does
+    propagation work AT ALL when both ends are Python?). The kotlin-on-
+    sender combo exercises LXMF-kt's stamp generation + link-layer
+    message delivery. The kotlin-on-receiver combo exercises LXMF-kt's
+    two-phase propagation pull (listMessages + requestMessages). The
+    homogeneous kotlin combo exercises both ends of the Kotlin LXMF
+    implementation simultaneously — the most regression-prone path.
+    """
+    if "lxmf_trio" not in metafunc.fixturenames:
+        return
+
+    impls = get_impl_list(metafunc.config) or []
+    # Always include the reference — otherwise a --impl=kotlin-only run
+    # would skip the interop assertions entirely, which defeats the
+    # point of cross-impl testing. Same pattern as tests/wire/conftest.py.
+    peers = sorted(set(impls) | {"reference"})
+    # Middle slot is pinned to "lxmd" (the Python lxmd subprocess).
+    trios = [(sender, "lxmd", receiver) for sender in peers for receiver in peers]
+
+    ids = [f"{a}->{b}->{c}" for a, b, c in trios]
+    metafunc.parametrize("lxmf_trio", trios, ids=ids, scope="function")
+
+
+def _require_lxmd():
+    """Skip the current test if the `lxmd` binary is not on PATH.
+
+    lxmd is packaged with the LXMF python distribution as a console
+    entrypoint — `pip install lxmf` installs it. We don't install it as
+    part of the test setup (the conformance suite avoids side effects on
+    the host); the CI workflow must handle that. Skipping cleanly here
+    makes dev-loop failures self-explain rather than look like hangs.
+    """
+    if not shutil.which("lxmd"):
+        pytest.skip(
+            "lxmd binary not on PATH; install with `pip install lxmf`. "
+            "The LXMF propagation conformance suite requires a real lxmd "
+            "daemon for the middle peer, matching production deployments."
+        )
+
+
+@pytest.fixture
+def lxmf_trio(request):
+    """(sender_impl, propagation_node_impl, receiver_impl) tuple from
+    pytest_generate_tests."""
+    return request.param
+
+
+class _LxmfPeer:
+    """Thin wrapper around a BridgeClient that adds LXMF commands on top
+    of the wire-layer surface.
+
+    Owns its own wire handle (via the `_wire` attribute). Sender/receiver
+    peers also own an in-process LXMRouter via `lxmf_handle`. The middle
+    (propagation-node) peer does NOT call `lxmf_start` — it delegates
+    the entire LXMF role to a separate lxmd subprocess spawned via
+    `spawn_daemon_propagation_node`, which shares the wire bridge's RNS
+    via the AF_UNIX shared-instance mechanism.
+    """
+
+    def __init__(self, bridge: BridgeClient, role_label: str):
+        self.bridge = bridge
+        self.role_label = role_label
+        self._wire = _WirePeer(bridge, role_label)
+
+        self.lxmf_handle: str | None = None
+        self.delivery_dest_hash: bytes | None = None
+        self.lxmf_identity_hash: bytes | None = None
+        self.propagation_node_dest_hash: bytes | None = None
+        # True iff this peer spawned an lxmd subprocess — teardown calls
+        # lxmf_stop_daemon_propagation_node to reap it.
+        self._lxmd_running = False
+        # Filesystem path to lxmd's messagestore (only populated for the
+        # middle / propagation-node peer). Used by stored_message_count()
+        # to assert on the prop node's on-disk state without routing a
+        # query through the bridge.
+        self._messagestore_dir: str | None = None
+
+    # --- Wire-layer pass-throughs (so tests don't have to juggle both). ---
+
+    def start_tcp_server(
+        self, network_name: str = "", passphrase: str = "",
+        share_instance: bool = False,
+    ) -> int:
+        # Propagation-node role needs share_instance=True so lxmd can
+        # attach. For sender/receiver the flag must stay False — otherwise
+        # multiple bridge subprocesses in the same test would fight over
+        # the AF_UNIX abstract socket namespace.
+        if share_instance:
+            resp = self.bridge.execute(
+                "wire_start_tcp_server",
+                network_name=network_name,
+                passphrase=passphrase,
+                share_instance=True,
+            )
+            self._wire.handle = resp["handle"]
+            self._wire.identity_hash = bytes.fromhex(resp["identity_hash"])
+            self._wire.port = int(resp["port"])
+            return self._wire.port
+        return self._wire.start_tcp_server(network_name, passphrase)
+
+    def start_tcp_client(
+        self, network_name: str = "", passphrase: str = "",
+        target_host: str = "127.0.0.1", target_port: int = 0,
+    ):
+        self._wire.start_tcp_client(network_name, passphrase, target_host, target_port)
+
+    def poll_path(self, destination_hash: bytes, timeout_ms: int = 5000) -> bool:
+        return self._wire.poll_path(destination_hash, timeout_ms=timeout_ms)
+
+    @property
+    def wire_handle(self) -> str | None:
+        return self._wire.handle
+
+    # --- LXMF-layer commands. ---
+
+    def lxmf_start(self, display_name: str | None = None) -> bytes:
+        """Attach an in-process LXMRouter to this peer's wire RNS.
+
+        Sender/receiver call this. The middle peer doesn't — it uses
+        lxmd as a separate subprocess via spawn_daemon_propagation_node.
+        """
+        assert self._wire.handle, "start_tcp_* must be called before lxmf_start"
+        params = {"wire_handle": self._wire.handle}
+        if display_name is not None:
+            params["display_name"] = display_name
+        resp = self.bridge.execute("lxmf_start", **params)
+        self.lxmf_handle = resp["handle"]
+        self.delivery_dest_hash = bytes.fromhex(resp["delivery_dest_hash"])
+        self.lxmf_identity_hash = bytes.fromhex(resp["identity_hash"])
+        return self.delivery_dest_hash
+
+    def spawn_daemon_propagation_node(
+        self,
+        display_name: str = "conformance-prop-node",
+        startup_timeout_sec: float = 30.0,
+    ) -> bytes:
+        """Spawn an lxmd subprocess that runs as this peer's propagation
+        node. The wire bridge must have been started with
+        share_instance=True so lxmd can attach to its Reticulum.
+
+        Returns the propagation destination hash that sender/receiver
+        peers pass to set_outbound_propagation_node.
+        """
+        assert self._wire.handle, "start_tcp_server must be called first"
+        resp = self.bridge.execute(
+            "lxmf_spawn_daemon_propagation_node",
+            wire_handle=self._wire.handle,
+            display_name=display_name,
+            startup_timeout_sec=startup_timeout_sec,
+        )
+        self.propagation_node_dest_hash = bytes.fromhex(
+            resp["propagation_node_dest_hash"]
+        )
+        self._messagestore_dir = resp.get("messagestore_dir")
+        self._lxmd_running = True
+        return self.propagation_node_dest_hash
+
+    def stored_message_count(self) -> int:
+        """Count lxmd's on-disk stored propagation messages.
+
+        Each message lxmd accepts lands as a single file named
+        `{transient_id_hex}_{received}[_{stamp_value}]` in the
+        messagestore dir (see LXMF/LXMRouter.py line 2329). Count is
+        exact — no subdirectories, no sidecars, just one file per
+        stored message. If lxmd hasn't yet created the directory
+        (can happen in the brief window between spawn and the first
+        stored message), return 0 rather than raising.
+
+        Only valid on the middle peer — the sender/receiver peers
+        don't own a messagestore dir.
+        """
+        assert self._messagestore_dir is not None, (
+            f"stored_message_count() is only valid on the propagation-node "
+            f"peer ({self.role_label} has no messagestore dir — call "
+            f"spawn_daemon_propagation_node first)"
+        )
+        if not os.path.isdir(self._messagestore_dir):
+            # Dir doesn't exist yet — LXMRouter creates it lazily on
+            # first propagated-message receive (see LXMRouter.py line
+            # 540: `if not os.path.isdir(self.messagepath): os.makedirs
+            # (self.messagepath)`). Returning 0 here lets the caller's
+            # wait-loop continue polling until lxmd creates the dir
+            # and writes the file.
+            return 0
+        # Plain listing: LXMRouter writes one file per stored message
+        # directly in messagepath, no nested dirs. Filter to files only
+        # (defensive against stray subdirs in unusual configurations).
+        entries = os.listdir(self._messagestore_dir)
+        return sum(
+            1
+            for name in entries
+            if os.path.isfile(os.path.join(self._messagestore_dir, name))
+        )
+
+    def wait_for_stored_message_count(
+        self, expected: int, timeout_s: float = 15.0
+    ) -> bool:
+        """Poll stored_message_count() until it reaches `expected` or
+        `timeout_s` elapses. Returns True iff the FINAL count (after the
+        poll loop exits) equals expected — callers assert on the return
+        value so a "reached expected then went past it" scenario still
+        fails loudly (tight assertion per the feedback memo).
+
+        The message-settle gap between sender.handle_outbound completing
+        and lxmd writing the file is measured in sub-seconds on loopback;
+        the default 15s is generous enough for CI jitter + slow stamp
+        generation while still failing fast when propagation is broken.
+        """
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            if self.stored_message_count() == expected:
+                # Linger a hair to make sure a just-arriving duplicate
+                # would still fail the FINAL equality check below.
+                time.sleep(0.2)
+                return self.stored_message_count() == expected
+            time.sleep(0.2)
+        return self.stored_message_count() == expected
+
+    def set_outbound_propagation_node(self, propagation_node_dest_hash: bytes):
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        self.bridge.execute(
+            "lxmf_set_outbound_propagation_node",
+            handle=self.lxmf_handle,
+            propagation_node_dest_hash=propagation_node_dest_hash.hex(),
+        )
+
+    def send_propagated(
+        self, recipient_delivery_dest_hash: bytes, content: str, title: str = "",
+    ) -> bytes:
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        resp = self.bridge.execute(
+            "lxmf_send_propagated",
+            handle=self.lxmf_handle,
+            recipient_delivery_dest_hash=recipient_delivery_dest_hash.hex(),
+            content=content,
+            title=title,
+        )
+        return bytes.fromhex(resp["message_hash"]) if resp.get("message_hash") else b""
+
+    def sync_inbound(self, timeout_s: float = _SYNC_TIMEOUT_MS / 1000.0) -> int:
+        """Ask the LXMRouter to fetch messages from its active propagation
+        node. Blocks until the router's transfer state machine settles or
+        the timeout elapses. Returns the number of messages transferred
+        (propagation_transfer_last_result)."""
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        resp = self.bridge.execute(
+            "lxmf_sync_inbound",
+            handle=self.lxmf_handle,
+            timeout_ms=int(timeout_s * 1000),
+        )
+        return int(resp.get("messages_received", 0))
+
+    def poll_inbox(self) -> list:
+        """Drain all delivered LXMessages since the last poll. Returns a
+        list of dicts with keys: hash, source, destination, title,
+        content, fields."""
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        resp = self.bridge.execute("lxmf_poll_inbox", handle=self.lxmf_handle)
+        return list(resp.get("messages", []))
+
+    def stop(self):
+        # Teardown order: lxmd subprocess first (if any), then in-process
+        # LXMRouter, then the wire singleton. lxmd-first matters because
+        # lxmd's LocalClientInterface disconnect is cleaner while the
+        # shared-instance server is still alive.
+        if self._lxmd_running and self._wire.handle is not None:
+            try:
+                self.bridge.execute(
+                    "lxmf_stop_daemon_propagation_node",
+                    wire_handle=self._wire.handle,
+                )
+            except Exception:
+                pass
+            self._lxmd_running = False
+        if self.lxmf_handle is not None:
+            try:
+                self.bridge.execute("lxmf_stop", handle=self.lxmf_handle)
+            except Exception:
+                pass
+            self.lxmf_handle = None
+        self._wire.stop()
+
+
+@pytest.fixture
+def lxmf_3peer(lxmf_trio):
+    """Three bridge subprocesses wired up as sender → prop_node ← receiver,
+    with sender/receiver running in-process LXMRouters and the middle peer
+    running a real `lxmd` subprocess attached via shared-instance.
+
+    Setup sequence (order matters — announces must propagate before
+    identity.recall can succeed on the recipient side):
+
+      1. prop_node brings up TCPServer with share_instance=True; note
+         the port. This publishes its RNS as an AF_UNIX shared instance.
+      2. sender + receiver bring up TCPClient targeting that port.
+      3. prop_node.spawn_daemon_propagation_node. An lxmd subprocess
+         starts, attaches to the shared RNS, and announces its
+         propagation destination over TCP to sender + receiver.
+      4. sender.lxmf_start, receiver.lxmf_start — each attaches an
+         in-process LXMRouter and announces its delivery destination.
+      5. Sleep to let all announces settle on all three peers.
+      6. sender.set_outbound_propagation_node(pn_hash).
+      7. receiver.set_outbound_propagation_node(pn_hash).
+
+    Yields (sender, prop_node, receiver) as `_LxmfPeer` objects.
+    """
+    _require_lxmd()
+
+    sender_impl, pn_impl, receiver_impl = lxmf_trio
+
+    # Sanity: middle slot is always "lxmd" (the Python lxmd subprocess).
+    # If a follow-up parametrization ever ships an lxmd-kt variant, the
+    # spawn command needs to be dispatched by pn_impl; until then, fail
+    # loudly if it drifts.
+    if pn_impl != "lxmd":
+        pytest.fail(
+            f"lxmf_3peer fixture only supports pn_impl='lxmd', got "
+            f"{pn_impl!r}. Add the new impl to the non-SUT resolver "
+            f"before parametrizing over it."
+        )
+
+    bridges = [
+        BridgeClient(
+            _resolve_command_for_trio(sender_impl),
+            env=_env_for(sender_impl),
+        ),
+        BridgeClient(
+            # Middle peer is always the Python reference bridge: it
+            # orchestrates lxmd as a subprocess and owns the shared-
+            # instance RNS.
+            _resolve_command_for_trio("reference"),
+            env=_env_for("reference"),
+        ),
+        BridgeClient(
+            _resolve_command_for_trio(receiver_impl),
+            env=_env_for(receiver_impl),
+        ),
+    ]
+    sender = _LxmfPeer(bridges[0], role_label=f"sender({sender_impl})")
+    prop_node = _LxmfPeer(bridges[1], role_label=f"prop_node({pn_impl})")
+    receiver = _LxmfPeer(bridges[2], role_label=f"receiver({receiver_impl})")
+
+    try:
+        # Step 1-2: wire layer. prop_node uses share_instance=True so
+        # the lxmd subprocess can attach to its Reticulum.
+        port = prop_node.start_tcp_server(share_instance=True)
+        sender.start_tcp_client(target_port=port)
+        receiver.start_tcp_client(target_port=port)
+        time.sleep(_SETTLE_SEC)
+
+        # Step 3: spawn lxmd. This blocks until lxmd logs the
+        # "LXMF Propagation Node started on <hex>" line (or timeout).
+        # The announce goes out over TCP as part of lxmd's startup.
+        pn_hash = prop_node.spawn_daemon_propagation_node(
+            display_name="conformance-prop-node",
+            startup_timeout_sec=30.0,
+        )
+
+        # Step 4: sender + receiver in-process LXMRouters. Each announces
+        # its delivery destination as part of lxmf_start. We STAGGER these:
+        # if both announces hit the middle peer in the same tick, RNS's
+        # Transport rate-limiter on the spawned TCPInterface for each
+        # client ends up queuing the second-direction rebroadcast, and in
+        # the specific sequence "sender announces then receiver announces
+        # in the same jiffy" the receiver's announce never reaches the
+        # sender's spawned interface queue before the rebroadcast retry
+        # limit fires. Empirically a 3s gap between the two lxmf_start
+        # calls is enough for the rebroadcast chain to complete cleanly;
+        # tighter gaps (<1s) leave sender without a path to receiver.
+        sender.lxmf_start(display_name="conformance-sender")
+        time.sleep(_INTER_ANNOUNCE_STAGGER_SEC)
+        receiver.lxmf_start(display_name="conformance-receiver")
+
+        # Step 5: let announces settle on all sides. The sender needs
+        # the receiver's delivery announce so Identity.recall succeeds
+        # in lxmf_send_propagated. The sender and receiver both need
+        # the propagation node's announce so set_outbound_propagation_node
+        # can find its identity for link establishment. The propagation
+        # node's announce has to traverse lxmd → LocalClientInterface →
+        # LocalServerInterface (wire bridge) → TCPServerInterface → both
+        # clients, so give it a generous window.
+        time.sleep(_ANNOUNCE_PROPAGATION_SEC)
+
+        # Guard: if the sender's path table never learned the receiver's
+        # delivery hash, the test below is going to fail for a
+        # meaningless reason (no path, not "propagation didn't work").
+        # Surface this explicitly so the failure diagnosis is crisp.
+        assert sender.poll_path(
+            receiver.delivery_dest_hash, timeout_ms=_SYNC_TIMEOUT_MS
+        ), (
+            f"{sender.role_label} did not learn a path to "
+            f"{receiver.role_label}'s delivery destination "
+            f"({receiver.delivery_dest_hash.hex()}) within "
+            f"{_SYNC_TIMEOUT_MS}ms; topology didn't converge."
+        )
+        assert sender.poll_path(
+            pn_hash, timeout_ms=_SYNC_TIMEOUT_MS
+        ), (
+            f"{sender.role_label} did not learn a path to the "
+            f"propagation node ({pn_hash.hex()}) within {_SYNC_TIMEOUT_MS}ms."
+        )
+        assert receiver.poll_path(
+            pn_hash, timeout_ms=_SYNC_TIMEOUT_MS
+        ), (
+            f"{receiver.role_label} did not learn a path to the "
+            f"propagation node ({pn_hash.hex()}) within {_SYNC_TIMEOUT_MS}ms."
+        )
+
+        # Step 6-7: point sender + receiver at the propagation node.
+        sender.set_outbound_propagation_node(pn_hash)
+        receiver.set_outbound_propagation_node(pn_hash)
+
+        yield sender, prop_node, receiver
+    finally:
+        for peer in (sender, prop_node, receiver):
+            try:
+                peer.stop()
+            except Exception:
+                pass
+        for b in bridges:
+            try:
+                b.close()
+            except Exception:
+                pass

--- a/tests/lxmf/conftest.py
+++ b/tests/lxmf/conftest.py
@@ -314,9 +314,13 @@ class _LxmfPeer:
         deadline = time.time() + timeout_s
         while time.time() < deadline:
             if self.stored_message_count() == expected:
-                # Linger a hair to make sure a just-arriving duplicate
-                # would still fail the FINAL equality check below.
-                time.sleep(0.2)
+                # Linger past the poll cadence (0.2s) to make sure a
+                # just-arriving duplicate would still fail the FINAL
+                # equality check. 1s gives >=5x the poll interval so a
+                # duplicate landing within a full cycle after we first
+                # hit `expected` still registers. Costs <1s on the
+                # happy path (negligible vs. ~25s total test wall).
+                time.sleep(1.0)
                 return self.stored_message_count() == expected
             time.sleep(0.2)
         return self.stored_message_count() == expected

--- a/tests/lxmf/test_propagation.py
+++ b/tests/lxmf/test_propagation.py
@@ -1,0 +1,102 @@
+"""LXMF PROPAGATED delivery — end-to-end conformance test.
+
+Exercises the minimal end-to-end propagation topology:
+
+    sender → propagation_node → receiver
+
+Sender submits a PROPAGATED LXMessage via its LXMRouter. The message
+travels over the TCP wire + IFAC-free network to the propagation node
+(real lxmd subprocess), gets stored there, and the receiver later pulls
+it down with request_messages_from_propagation_node (driven by
+lxmf_sync_inbound on the bridge).
+
+Parametrized over the cartesian product of {reference, kotlin} for
+sender + receiver — 4 trios total with --impl=kotlin. The middle slot
+is always "lxmd" (the Python lxmd daemon) to keep the propagation-node
+path architecturally realistic.
+
+Scope intentionally tight:
+  - Single-packet text content (fits in one link DATA packet).
+  - No attachments, no IFAC, no stamp cost.
+"""
+
+import secrets
+import time
+
+
+_TITLE = "Propagation test"
+
+
+def test_propagated_delivery_round_trip(lxmf_trio, lxmf_3peer):
+    """Sender → lxmd propagation node → receiver, with three tight
+    assertions: (1) B's storage shows exactly 1 message, (2) C's
+    sync pulls exactly 1 message, (3) C's inbox is exactly 1 entry
+    with matching content / title / source.
+    """
+    sender, propagation_node, receiver = lxmf_3peer
+
+    # Random-tail content so a bug that reports cached / previous-run
+    # messages can't accidentally fake a pass. The fixture creates fresh
+    # bridge processes per test, so this is belt-and-suspenders — but
+    # cheap, and it makes the assertion genuinely unique per run.
+    content = f"MVP propagated message {secrets.token_hex(8)}"
+
+    message_hash = sender.send_propagated(
+        recipient_delivery_dest_hash=receiver.delivery_dest_hash,
+        content=content,
+        title=_TITLE,
+    )
+    assert message_hash, (
+        f"{sender.role_label}.send_propagated returned empty message_hash; "
+        f"the sender did not finish packing the outbound LXMessage."
+    )
+
+    # Assertion 1: B's storage shows exactly 1 message. Bounded wait
+    # — the sender → propagation-node transfer takes up to ~25s on
+    # loopback when the Kotlin sender is generating a PROPAGATION_COST=16
+    # stamp (~65k attempts). Add the link-setup + resource-transfer +
+    # file-write latency on top and 30s is a comfortable ceiling that
+    # still fails fast if the path is actually broken. Tight equality
+    # on the FINAL count catches both under- and over-storage.
+    assert propagation_node.wait_for_stored_message_count(
+        expected=1, timeout_s=30.0
+    ), (
+        f"lxmd storage never reached exactly 1 stored message; final "
+        f"count = {propagation_node.stored_message_count()}. "
+        f"0 = sender→node transfer broken; >1 = the sender/router sent "
+        f"the message multiple times or lxmd duplicated on disk."
+    )
+
+    # Assertion 2: C's sync_inbound returns exactly 1 message pulled.
+    synced = receiver.sync_inbound(timeout_s=15.0)
+    assert synced == 1, (
+        f"{receiver.role_label}.sync_inbound returned {synced} messages "
+        f"received, expected exactly 1. 0 = pull path broken "
+        f"(link/list/request); >1 = sync reported duplicates."
+    )
+
+    # Assertion 3: C's poll_inbox is exactly length 1 with matching
+    # content, title, source. Tight equality per feedback memo.
+    inbox = receiver.poll_inbox()
+    assert len(inbox) == 1, (
+        f"{receiver.role_label} inbox has {len(inbox)} entries, expected "
+        f"exactly 1. Inbox: {inbox!r}. "
+        f"0 = sync reported success but delivery callback never fired; "
+        f">1 = duplicate delivery."
+    )
+    assert inbox[0]["content"] == content, (
+        f"content mismatch: got {inbox[0]['content']!r}, "
+        f"expected {content!r}"
+    )
+    assert inbox[0]["title"] == _TITLE, (
+        f"title mismatch: got {inbox[0]['title']!r}, "
+        f"expected {_TITLE!r}"
+    )
+    # Sender hash on the inbox entry is the sender's delivery dest hash
+    # (what Python sets as source_hash on the received message). This
+    # catches a class of bugs where the encryption-for-recipient step
+    # mangles the source attribution.
+    assert inbox[0]["source"] == sender.delivery_dest_hash.hex(), (
+        f"source mismatch: got {inbox[0]['source']!r}, "
+        f"expected {sender.delivery_dest_hash.hex()!r}"
+    )


### PR DESCRIPTION
## Summary

- Adds a new `tests/lxmf/` category for LXMF-layer conformance tests, parallel to the existing `tests/wire/` RNS-layer category.
- Parametrizes over the cartesian product of `{reference, kotlin}` for sender + receiver — 4 trios total with `--impl=kotlin`. Middle slot is pinned to `"lxmd"` (the Python lxmd daemon subprocess).
- The middle peer runs a REAL `lxmd` subprocess (the LXMF daemon shipped with the LXMF python package) attached to the wire bridge's Reticulum via the AF_UNIX shared-instance mechanism. This matches how production propagation nodes are deployed (see `fleet/yggdrasil/reticulum-node.yaml` — rnsd + lxmd sharing `/root/.reticulum`).
- Three tight assertions per trio: (1) B's on-disk messagestore has exactly 1 file, (2) C's `sync_inbound()` returns exactly 1 message received, (3) C's `poll_inbox()` is exactly one entry with matching content/title/source.

## Parametrization matrix

All 4 combos pass locally:

| Trio | Status |
|------|--------|
| `reference -> lxmd -> reference` | PASS |
| `reference -> lxmd -> kotlin`    | PASS |
| `kotlin -> lxmd -> reference`    | PASS |
| `kotlin -> lxmd -> kotlin`       | PASS |

Total wall-clock: ~107-113s for the full 4-combo run (~27s each). Back-to-back runs leave `pgrep lxmd` empty before and after.

## What this proves

- LXMF-kt's sender can build a PROPAGATED LXMessage, generate a propagation stamp (cost 16), establish a link to lxmd, and transfer the message — to both Python and Kotlin receivers.
- The Python reference sender can do the same (with a stamp-generation workaround, see below).
- lxmd stores exactly one file per message in `<config>/storage/lxmf/messagestore/` (file name is `<transient_id>_<received>_<stamp_value>`).
- LXMF-kt's receiver successfully drives `requestMessagesFromPropagationNode()`, pulls the message off lxmd, decrypts it, and fires the delivery callback.
- End-to-end tight assertions (`len(inbox) == 1`, `sync_inbound == 1`, exact content/title/source) pass on all 4 parametrizations.

## Stored-message assertion

`propagation_node.wait_for_stored_message_count(expected=1, timeout_s=30.0)` polls `<lxmd_config_dir>/storage/lxmf/messagestore/` on the same filesystem the lxmd subprocess writes to. Timeout is generous (30s) because Kotlin-sender stamp generation can take ~25s on loopback; tight equality on the FINAL count catches both under- (broken transfer) and over-storage (duplicate delivery).

The path derivation is non-obvious: lxmd passes `storagepath=<configdir>/storage` to `LXMRouter(...)`, and `LXMRouter` internally appends `/lxmf` before `/messagestore`, so messages land at `<configdir>/storage/lxmf/messagestore`. Verified empirically.

## Python sender stamp-deferral fix

`LXMessage` defaults `defer_propagation_stamp=True`, which parks PROPAGATED messages in `pending_deferred_stamps` instead of sending them immediately. The deferred-stamp jobloop is designed for interactive app usage and does NOT reliably fire within a conformance test's ~30s window — `reference→lxmd→receiver` silently lost messages before this fix.

`cmd_lxmf_send_propagated` now calls `router.get_outbound_propagation_cost()` + `message.get_propagation_stamp(target_cost=...)` synchronously before `handle_outbound`, so the non-deferred path (LXMRouter.py line 1673) is taken. Kotlin's LXMF-kt already does the equivalent via its synchronous propagation-stamp path.

## Inter-announce stagger

Simultaneous bidirectional announces from sender + receiver through a shared middle peer race RNS's per-interface announce rate-limiter. 3s stagger between `sender.lxmf_start` and `receiver.lxmf_start` works across all 4 orderings; verified that `reference→lxmd→kotlin` and `kotlin→lxmd→reference` (opposite orderings of the SUT on sender vs receiver) both converge.

## What changed at the bridge surface

**Python reference bridge** (`reference/lxmf_bridge.py`):
- `wire_start_tcp_server` already had optional `share_instance=True` (from prior MVP); retained.
- `lxmf_spawn_daemon_propagation_node` now returns `lxmd_config_dir` and `messagestore_dir` so the fixture can glob the on-disk storage count directly without routing a query through the bridge.
- `lxmf_send_propagated` synchronously generates the propagation stamp before submitting (fixes the stamp-deferral issue described above).

**Kotlin bridge** (`conformance-bridge/src/main/kotlin/Lxmf.kt`, paired PR torlando-tech/reticulum-kt#43):
- `lxmf_sync_inbound` drives `LXMRouter.requestMessagesFromPropagationNode()` and polls `propagationTransferState` until a terminal state; returns `propagationTransferLastResult`.
- `lxmf_poll_inbox` drains the delivery-callback inbox atomically.

**Test fixture** (`tests/lxmf/conftest.py`):
- `_LxmfPeer.stored_message_count()` returns `len(os.listdir(messagestore_dir))` counting only regular files.
- `_LxmfPeer.wait_for_stored_message_count(expected, timeout_s)` polls until match or timeout, asserts on the FINAL count (not "reached at some point") so a duplicate arriving after the target count doesn't silently pass.

## Paired PR

Depends on torlando-tech/reticulum-kt#43 which adds the receiver-side `lxmf_sync_inbound` / `lxmf_poll_inbox` implementations on the Kotlin bridge.

## Test plan

- [x] `pytest tests/lxmf/test_propagation.py --impl=kotlin` — all 4 trios PASS locally (~107s)
- [x] Two consecutive full runs: both PASS; `pgrep lxmd` count 0 → 0 (teardown clean)
- [x] `pytest tests/wire/ --impl=kotlin` still green modulo 3 pre-existing flaky link-multihop tests unaffected by this PR
- [x] Skip-if-missing: removing lxmd from PATH skips the test cleanly with "lxmd binary not on PATH; install with pip install lxmf"
- [ ] CI picks up the new suite via LXMF-kt's future workflow (not in scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)