### PR TITLE
Add opportunistic + direct LXMF conformance tests (transport 3-peer)

### DIFF
--- a/reference/lxmf_bridge.py
+++ b/reference/lxmf_bridge.py
@@ -1,4 +1,20 @@
-"""LXMF conformance commands (E2E propagation interop harness).
+"""LXMF conformance commands (E2E interop harness).
+
+Covers all three LXMF delivery methods:
+
+  - PROPAGATED: sender submits to a propagation node (real lxmd
+    subprocess), receiver pulls it down via
+    request_messages_from_propagation_node.
+  - OPPORTUNISTIC: sender unicasts a single encrypted packet; no
+    link, no node. Single-packet only (oversized content is rejected
+    up-front rather than silently upgraded to DIRECT).
+  - DIRECT: sender opens a Link to the recipient's delivery
+    destination; payloads > MDU use a Resource for multi-packet
+    chunked transfer. This is the single-hop real-time path.
+
+The OPPORTUNISTIC and DIRECT tests use a plain-transport middle peer
+(no lxmd); only PROPAGATED spins up the lxmd subprocess.
+
 
 Layered ON TOP of the wire_tcp layer. The pattern:
 
@@ -43,6 +59,77 @@ import time
 
 _instances = {}
 _instances_lock = threading.Lock()
+
+
+def _encode_field_value_for_inbox(value):
+    """Recursively convert bytes -> hex in an LXMF field value.
+
+    Why recursive: the canonical Python-LXMF FIELD_FILE_ATTACHMENTS wire
+    shape is ``[[filename_str, data_bytes], ...]`` — raw ``bytes`` buried
+    inside a list. If we only handled the top level (``isinstance(v,
+    bytes)``), a call to json.dumps() on the resulting inbox entry would
+    raise TypeError, because ``bytes`` is not JSON-serializable at any
+    depth. Mirrored in Lxmf.kt's ``lxmfFieldValueToJson`` so the two
+    impls serialize attachments identically for tight cross-impl
+    assertion.
+
+    Scalar passthrough for ints / strs / bools / floats (JSON-native).
+    """
+    if isinstance(value, bytes):
+        return value.hex()
+    if isinstance(value, (list, tuple)):
+        return [_encode_field_value_for_inbox(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _encode_field_value_for_inbox(v) for k, v in value.items()}
+    return value
+
+
+def _decode_field_value_from_params(value):
+    """Inverse of _encode_field_value_for_inbox for the send-side.
+
+    Accepted JSON shapes (matches Lxmf.kt's lxmfFieldValueFromJson):
+      - ``{"bytes": "<hex>"}``     -> bytes
+      - ``{"str": "..."}``          -> str
+      - ``{"int": 123}``            -> int
+      - ``{"bool": true}``          -> bool
+      - a JSON array                -> list (recursive)
+      - a bare JSON primitive       -> its native type (passthrough)
+
+    The explicit-tag wrapper is load-bearing for FIELD_FILE_ATTACHMENTS:
+    attachment elements are ``[filename_str, data_bytes]``, and without
+    a tag there's no way to tell "hex-encoded bytes" from a literal
+    string value. Callers that want a straight list use the array shape
+    at the outer level; the inner bytes element uses the ``{"bytes":
+    ...}`` tag.
+    """
+    if isinstance(value, dict):
+        if "bytes" in value:
+            return bytes.fromhex(value["bytes"])
+        if "str" in value:
+            return value["str"]
+        if "int" in value:
+            return int(value["int"])
+        if "bool" in value:
+            return bool(value["bool"])
+        raise ValueError(
+            f"Unsupported LXMF field object shape; expected one of "
+            f"{{bytes|str|int|bool}}: {value!r}"
+        )
+    if isinstance(value, list):
+        return [_decode_field_value_from_params(v) for v in value]
+    # Bare JSON primitives pass through as-is.
+    return value
+
+
+def _decode_fields_param(fields_param):
+    """Convert the JSON ``fields`` dict (str keys -> tagged values) into
+    the ``dict[int, Any]`` shape LXMessage expects."""
+    if not fields_param:
+        return {}
+    decoded = {}
+    for k, v in fields_param.items():
+        decoded[int(k)] = _decode_field_value_from_params(v)
+    return decoded
 
 
 def _get_rns():
@@ -160,11 +247,16 @@ def cmd_lxmf_start(params):
                 else (message.content or "")
             ),
         }
-        # Fields are opaque bytes/values; serialize them as hex for bytes
-        # and keep primitives as-is so tests can assert on them directly.
+        # Fields may contain NESTED bytes — the canonical
+        # FIELD_FILE_ATTACHMENTS shape is [[filename_str, data_bytes]].
+        # json.dumps() raises TypeError on raw bytes at any nesting level,
+        # so we must recursively convert bytes -> hex anywhere inside a
+        # list/tuple/dict value. Mirrors the Kotlin bridge's
+        # lxmfFieldValueToJson so both impls serialize attachments
+        # identically for tight cross-impl assertion.
         fields = {}
         for k, v in (getattr(message, "fields", None) or {}).items():
-            fields[str(k)] = v.hex() if isinstance(v, bytes) else v
+            fields[str(k)] = _encode_field_value_for_inbox(v)
         entry["fields"] = fields
         with inbox_lock:
             inbox.append(entry)
@@ -705,6 +797,165 @@ def cmd_lxmf_send_propagated(params):
     }
 
 
+def cmd_lxmf_send_opportunistic(params):
+    """Build + submit an LXMessage with OPPORTUNISTIC delivery.
+
+    Single-packet unicast over any available interface — no link
+    setup, no propagation node, no stamp. Oversized content fails
+    up-front rather than silently upgrading to DIRECT; the
+    conformance suite keeps opportunistic tests single-packet and
+    treats any upgrade as a distinct class of test (deferred).
+
+    params:
+        handle (str): lxmf_start handle for the sender.
+        recipient_delivery_dest_hash (hex): recipient's delivery hash.
+        content (str): UTF-8 message content.
+        title (str, optional): UTF-8 title, defaults to "".
+        fields (dict[str,Any], optional): int-keyed (as str) fields.
+            Values use the tagged-dict shape described in
+            _decode_field_value_from_params. Keep payload small —
+            LXMF will fall back to DIRECT for content + fields that
+            exceed LXMF.LXMessage.ENCRYPTED_PACKET_MAX_CONTENT and
+            we reject that up-front.
+
+    Returns:
+        message_hash (hex): LXMessage hash.
+    """
+    handle = params["handle"]
+    recipient_hash_hex = params["recipient_delivery_dest_hash"]
+    content = params["content"]
+    title = params.get("title", "")
+    fields = _decode_fields_param(params.get("fields"))
+
+    recipient_hash = bytes.fromhex(recipient_hash_hex)
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    RNS = _get_rns()
+    LXMF = _get_lxmf()
+
+    recipient_identity = RNS.Identity.recall(recipient_hash)
+    if recipient_identity is None:
+        raise RuntimeError(
+            f"No identity known for recipient {recipient_hash.hex()}. "
+            f"Ensure the recipient announced its delivery destination "
+            f"before calling lxmf_send_opportunistic."
+        )
+
+    recipient_destination = RNS.Destination(
+        recipient_identity,
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+
+    message = LXMF.LXMessage(
+        destination=recipient_destination,
+        source=inst["delivery_destination"],
+        content=content,
+        title=title,
+        fields=fields,
+        desired_method=LXMF.LXMessage.OPPORTUNISTIC,
+    )
+
+    router = inst["router"]
+
+    # Pack first so LXMessage.pack() has a chance to flip
+    # desired_method back to DIRECT if the packed size exceeds
+    # ENCRYPTED_PACKET_MAX_CONTENT. We want to surface that
+    # up-front rather than silently sending via DIRECT.
+    if not getattr(message, "packed", None):
+        message.pack()
+    if message.desired_method != LXMF.LXMessage.OPPORTUNISTIC:
+        raise RuntimeError(
+            f"Opportunistic delivery silently upgraded to method "
+            f"{message.desired_method} — content+fields exceeded "
+            f"LXMessage.ENCRYPTED_PACKET_MAX_CONTENT. Shrink the "
+            f"payload or use lxmf_send_direct."
+        )
+
+    router.handle_outbound(message)
+
+    return {
+        "message_hash": message.hash.hex() if message.hash else "",
+    }
+
+
+def cmd_lxmf_send_direct(params):
+    """Build + submit an LXMessage with DIRECT delivery.
+
+    Link-based — the router opens (or reuses) an outbound Link to
+    the recipient's delivery destination. Payloads > MDU go via a
+    Resource (multi-packet, chunked + reassembled by RNS). This is
+    the single-hop real-time delivery path LXMF uses when both
+    peers are online.
+
+    params:
+        handle (str): lxmf_start handle for the sender.
+        recipient_delivery_dest_hash (hex): recipient's delivery hash.
+        content (str): UTF-8 message content (any size).
+        title (str, optional): UTF-8 title, defaults to "".
+        fields (dict[str,Any], optional): same shape as
+            lxmf_send_opportunistic. Large values (e.g. file
+            attachments) are fine here — they'll be chunked by the
+            Resource API transparently.
+
+    Returns:
+        message_hash (hex): LXMessage hash.
+    """
+    handle = params["handle"]
+    recipient_hash_hex = params["recipient_delivery_dest_hash"]
+    content = params["content"]
+    title = params.get("title", "")
+    fields = _decode_fields_param(params.get("fields"))
+
+    recipient_hash = bytes.fromhex(recipient_hash_hex)
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    RNS = _get_rns()
+    LXMF = _get_lxmf()
+
+    recipient_identity = RNS.Identity.recall(recipient_hash)
+    if recipient_identity is None:
+        raise RuntimeError(
+            f"No identity known for recipient {recipient_hash.hex()}. "
+            f"Ensure the recipient announced its delivery destination "
+            f"before calling lxmf_send_direct."
+        )
+
+    recipient_destination = RNS.Destination(
+        recipient_identity,
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        "lxmf",
+        "delivery",
+    )
+
+    message = LXMF.LXMessage(
+        destination=recipient_destination,
+        source=inst["delivery_destination"],
+        content=content,
+        title=title,
+        fields=fields,
+        desired_method=LXMF.LXMessage.DIRECT,
+    )
+
+    router = inst["router"]
+    router.handle_outbound(message)
+
+    return {
+        "message_hash": message.hash.hex() if message.hash else "",
+    }
+
+
 def cmd_lxmf_sync_inbound(params):
     """Ask this peer's LXMRouter to fetch stored messages from its
     configured outbound propagation node.
@@ -931,6 +1182,8 @@ LXMF_COMMANDS = {
     "lxmf_stop_daemon_propagation_node": cmd_lxmf_stop_daemon_propagation_node,
     "lxmf_set_outbound_propagation_node": cmd_lxmf_set_outbound_propagation_node,
     "lxmf_send_propagated": cmd_lxmf_send_propagated,
+    "lxmf_send_opportunistic": cmd_lxmf_send_opportunistic,
+    "lxmf_send_direct": cmd_lxmf_send_direct,
     "lxmf_sync_inbound": cmd_lxmf_sync_inbound,
     "lxmf_poll_inbox": cmd_lxmf_poll_inbox,
     "lxmf_stop": cmd_lxmf_stop,

--- a/tests/lxmf/conftest.py
+++ b/tests/lxmf/conftest.py
@@ -1,26 +1,49 @@
-"""LXMF-layer (propagation E2E) fixtures.
+"""LXMF-layer (E2E) fixtures.
 
 Layered on top of tests/wire/. The wire layer spins up a real Reticulum +
 TCP interface per bridge; the LXMF layer attaches an LXMRouter to that
-same RNS instance and exercises PROPAGATED delivery across three peers:
+same RNS instance and exercises all three delivery methods.
 
-    sender (TCPClient)                    receiver (TCPClient)
-           \\                                   /
-            `----> transport (TCPServer) <----'
-                   enable_transport=True
-                   share_instance=True
-                       └── lxmd subprocess (propagation node)
+Two 3-peer topologies live here:
 
-The middle peer wears two hats: its bridge process is the RNS TCP
-transport, and a SEPARATE `lxmd` subprocess attached to the same shared
-Reticulum is the LXMF propagation node. This matches how production
-deployments run propagation nodes (see fleet/yggdrasil/reticulum-node.yaml
-— rnsd + lxmd in the same container, sharing `/root/.reticulum`).
+    1) lxmf_3peer (PROPAGATED delivery, middle = lxmd subprocess):
 
-MVP emits a single parametrization: (kotlin, lxmd, reference). The middle
-slot is "lxmd" (not "reference") to make it architecturally explicit that
-it's a separate daemon process, not an in-router mode. If LXMF-kt ever
-grows a daemon equivalent, the slot could become "lxmd-kt".
+         sender (TCPClient)                    receiver (TCPClient)
+                \\                                   /
+                 `----> transport (TCPServer) <----'
+                        enable_transport=true
+                        share_instance=true
+                            └── lxmd subprocess (propagation node)
+
+       The middle peer wears two hats: its bridge process is the RNS TCP
+       transport, and a SEPARATE lxmd subprocess attached to the same
+       shared Reticulum is the LXMF propagation node. Matches production
+       (see fleet/yggdrasil/reticulum-node.yaml — rnsd + lxmd in the
+       same container, sharing /root/.reticulum).
+
+    2) lxmf_transport_3peer (OPPORTUNISTIC and DIRECT delivery, middle
+       = plain transport, NO lxmd):
+
+         sender (TCPClient)                    receiver (TCPClient)
+                \\                                   /
+                 `----> transport (TCPServer) <----'
+                        enable_transport=true
+
+       The middle is JUST a packet mover. sender and receiver run
+       in-process LXMRouters against their own bridge RNS; the middle
+       has no LXMF state of its own. This matches how LXMF works when
+       both peers are online and there's a transport hop between them
+       (the typical Columba ↔ rnsd ↔ Sideband path).
+
+Both fixtures share the lxmf_start + announce-stagger + path-convergence
+logic in _setup_lxmf_peers_on_transport — only the middle-peer role
+configuration differs.
+
+Parametrization emits 4 combos for each fixture via lxmf_trio:
+(kotlin|reference) × (kotlin|reference) on the sender/receiver slots. The
+middle is always "lxmd" for propagation and always "reference" for
+transport (lxmf-kt has no equivalent transport-mode node distinct from
+enable_transport=true anyway).
 
 See reference/lxmf_bridge.py and conformance-bridge/src/main/kotlin/
 Lxmf.kt for the command surface these fixtures drive.
@@ -89,26 +112,33 @@ _SYNC_TIMEOUT_MS = 30_000
 
 
 def pytest_generate_tests(metafunc):
-    """Parametrize LXMF tests over (sender_impl, prop_node_impl, receiver_impl).
+    """Parametrize LXMF tests over (sender_impl, middle_impl, receiver_impl).
 
-    The middle slot is always "lxmd" — architecturally a Python subprocess
-    running the real lxmd daemon (not an in-router-mode LXMRouter). The
-    tuple shape is kept future-proof: if LXMF-kt ever ships a daemon, the
-    middle could become "lxmd-kt". Today, "lxmd" is the only value that
-    makes sense for a separate-process propagation node.
+    The middle slot depends on which fixture is in use:
+      - lxmf_3peer (PROPAGATED): middle = "lxmd" (separate Python
+        subprocess running the real lxmd daemon, not an in-router-mode
+        LXMRouter). Future-proof: if LXMF-kt ever ships a daemon, the
+        middle could become "lxmd-kt".
+      - lxmf_transport_3peer (OPPORTUNISTIC / DIRECT): middle =
+        "reference" (plain Python transport, no LXMF state of its own).
+        LXMF-kt has no equivalent transport-mode node distinct from the
+        wire bridge's enable_transport=true — sticking with reference
+        for the middle keeps Phase 1 scope focused on the cross-impl
+        sender/receiver matrix.
 
     Cartesian product over impls ∪ {"reference"} for sender + receiver:
-    with --impl=kotlin this emits 4 combos (reference and kotlin on each
-    end). Mirrors the wire-layer `_parametrize_wire_trio` pattern so the
-    matrix shape is consistent across test categories.
+    with --impl=kotlin this emits 4 combos per fixture (reference and
+    kotlin on each end). Mirrors the wire-layer
+    `_parametrize_wire_trio` pattern so the matrix shape is consistent
+    across test categories.
 
     The reference-only combo is the end-to-end sanity baseline (does
-    propagation work AT ALL when both ends are Python?). The kotlin-on-
-    sender combo exercises LXMF-kt's stamp generation + link-layer
-    message delivery. The kotlin-on-receiver combo exercises LXMF-kt's
-    two-phase propagation pull (listMessages + requestMessages). The
-    homogeneous kotlin combo exercises both ends of the Kotlin LXMF
-    implementation simultaneously — the most regression-prone path.
+    the delivery method work AT ALL when both ends are Python?). The
+    kotlin-on-sender combo exercises LXMF-kt's send path. The
+    kotlin-on-receiver combo exercises LXMF-kt's inbound decrypt +
+    delivery callback. The homogeneous kotlin combo exercises both ends
+    of the Kotlin LXMF implementation simultaneously — the most
+    regression-prone path.
     """
     if "lxmf_trio" not in metafunc.fixturenames:
         return
@@ -118,8 +148,22 @@ def pytest_generate_tests(metafunc):
     # would skip the interop assertions entirely, which defeats the
     # point of cross-impl testing. Same pattern as tests/wire/conftest.py.
     peers = sorted(set(impls) | {"reference"})
-    # Middle slot is pinned to "lxmd" (the Python lxmd subprocess).
-    trios = [(sender, "lxmd", receiver) for sender in peers for receiver in peers]
+
+    # Decide which middle-slot label to emit based on the fixture the
+    # test asked for. A test that pulls in BOTH fixtures (not a real
+    # pattern, but defensive) would get the propagation-appropriate
+    # label because lxmd is the more-constrained case.
+    if "lxmf_3peer" in metafunc.fixturenames:
+        middle = "lxmd"
+    elif "lxmf_transport_3peer" in metafunc.fixturenames:
+        middle = "reference"
+    else:
+        # Test took lxmf_trio but neither topology fixture — fall back
+        # to the propagation label so the test's fixture choice is the
+        # thing that fails, not the parametrization.
+        middle = "lxmd"
+
+    trios = [(sender, middle, receiver) for sender in peers for receiver in peers]
 
     ids = [f"{a}->{b}->{c}" for a, b, c in trios]
     metafunc.parametrize("lxmf_trio", trios, ids=ids, scope="function")
@@ -345,6 +389,53 @@ class _LxmfPeer:
         )
         return bytes.fromhex(resp["message_hash"]) if resp.get("message_hash") else b""
 
+    def send_opportunistic(
+        self,
+        recipient_delivery_dest_hash: bytes,
+        content: str,
+        title: str = "",
+        fields: dict | None = None,
+    ) -> bytes:
+        """Send an LXMessage with OPPORTUNISTIC delivery (single-packet).
+
+        The bridge accepts the same tagged-dict field shape as
+        send_direct. Bytes inside field values use the ``{"bytes":
+        "<hex>"}`` wrapper; see lxmfFieldValueFromJson (Kotlin) /
+        _decode_field_value_from_params (Python) for the full shape.
+        """
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        params = {
+            "handle": self.lxmf_handle,
+            "recipient_delivery_dest_hash": recipient_delivery_dest_hash.hex(),
+            "content": content,
+            "title": title,
+        }
+        if fields is not None:
+            params["fields"] = fields
+        resp = self.bridge.execute("lxmf_send_opportunistic", **params)
+        return bytes.fromhex(resp["message_hash"]) if resp.get("message_hash") else b""
+
+    def send_direct(
+        self,
+        recipient_delivery_dest_hash: bytes,
+        content: str,
+        title: str = "",
+        fields: dict | None = None,
+    ) -> bytes:
+        """Send an LXMessage with DIRECT delivery (link-based; payloads
+        > MDU use a Resource for multi-packet chunked transfer)."""
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        params = {
+            "handle": self.lxmf_handle,
+            "recipient_delivery_dest_hash": recipient_delivery_dest_hash.hex(),
+            "content": content,
+            "title": title,
+        }
+        if fields is not None:
+            params["fields"] = fields
+        resp = self.bridge.execute("lxmf_send_direct", **params)
+        return bytes.fromhex(resp["message_hash"]) if resp.get("message_hash") else b""
+
     def sync_inbound(self, timeout_s: float = _SYNC_TIMEOUT_MS / 1000.0) -> int:
         """Ask the LXMRouter to fetch messages from its active propagation
         node. Blocks until the router's transfer state machine settles or
@@ -365,6 +456,59 @@ class _LxmfPeer:
         assert self.lxmf_handle, "lxmf_start must be called first"
         resp = self.bridge.execute("lxmf_poll_inbox", handle=self.lxmf_handle)
         return list(resp.get("messages", []))
+
+    def wait_for_inbox_count(
+        self, expected: int, timeout_s: float = 30.0
+    ) -> list:
+        """Poll the inbox (non-draining) until it has exactly ``expected``
+        messages, then drain and return them.
+
+        Why non-draining on the probe: opportunistic / direct delivery
+        doesn't have a sync_inbound call to block on. The router's
+        delivery callback enqueues onto the inbox asynchronously after
+        packet reception / link transfer completes. A naive poll_inbox
+        would drain mid-arrival and report 0 before the delivery
+        callback has fired.
+
+        The shape here mirrors wait_for_stored_message_count from the
+        propagation path: wait until the count is exactly ``expected``,
+        linger briefly to catch duplicates, then drain + return. A
+        duplicate that arrives WITHIN the linger window flips the
+        count to expected+1 and the final check fails — which is what
+        we want, per the tight-assertions memo.
+
+        Implementation detail: the bridge's lxmf_poll_inbox drains
+        atomically, so we can't "peek at count" without draining.
+        Instead we drain-and-accumulate in a local buffer; once the
+        accumulated count matches ``expected``, we linger and do ONE
+        more drain to catch duplicates.
+
+        Returns the accumulated list on success. Raises AssertionError
+        on timeout or on count!=expected after the final check; tests
+        that need a non-raising variant can catch and inspect.
+        """
+        assert self.lxmf_handle, "lxmf_start must be called first"
+        accumulated: list = []
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            fresh = self.poll_inbox()
+            accumulated.extend(fresh)
+            if len(accumulated) >= expected:
+                break
+            time.sleep(0.2)
+
+        # Linger for a poll cycle (>0.2s) so any just-arriving duplicate
+        # still lands and flips the final count. 1s gives ~5x the poll
+        # cadence. Costs <1s on happy path.
+        time.sleep(1.0)
+        accumulated.extend(self.poll_inbox())
+
+        assert len(accumulated) == expected, (
+            f"{self.role_label} inbox count = {len(accumulated)}, "
+            f"expected exactly {expected} within {timeout_s}s. "
+            f"Inbox: {accumulated!r}"
+        )
+        return accumulated
 
     def stop(self):
         # Teardown order: lxmd subprocess first (if any), then in-process
@@ -387,6 +531,95 @@ class _LxmfPeer:
                 pass
             self.lxmf_handle = None
         self._wire.stop()
+
+
+def _start_lxmf_peers_and_wait_for_paths(
+    sender: "_LxmfPeer",
+    receiver: "_LxmfPeer",
+    extra_path_hashes: tuple[bytes, ...] = (),
+):
+    """Bring up in-process LXMRouters on the two endpoint peers,
+    stagger their announces, and wait for path convergence.
+
+    Extracted so `lxmf_3peer` (propagation) and `lxmf_transport_3peer`
+    (opportunistic / direct) can share this core without copy-paste.
+    The only difference between the two topologies is what the middle
+    peer is doing (lxmd subprocess vs. plain transport) — the
+    endpoint announce sequencing is identical.
+
+    Args:
+        sender: the peer that will send LXMessages (already wired at
+            the TCP layer via start_tcp_client).
+        receiver: the peer that will receive LXMessages (already
+            wired at the TCP layer via start_tcp_client).
+        extra_path_hashes: additional destination hashes both endpoints
+            must learn paths to (e.g. the propagation node hash).
+            The receiver's delivery hash is always waited on for the
+            sender, so it doesn't need to be in here.
+
+    Raises:
+        AssertionError: if any path fails to converge within
+            _SYNC_TIMEOUT_MS.
+
+    Why stagger the lxmf_start calls: if both announces hit the middle
+    peer in the same tick, RNS's Transport rate-limiter on the spawned
+    TCPInterface for each client queues the second-direction
+    rebroadcast. In the specific sequence "sender announces then
+    receiver announces in the same jiffy" the receiver's announce
+    never reaches the sender's spawned interface queue before the
+    rebroadcast retry limit fires. Empirically a 3s gap is enough for
+    the rebroadcast chain to complete cleanly; tighter gaps (<1s) leave
+    the sender without a path to the receiver. Matches the wire-layer
+    multihop fixtures.
+    """
+    sender.lxmf_start(display_name="conformance-sender")
+    time.sleep(_INTER_ANNOUNCE_STAGGER_SEC)
+    receiver.lxmf_start(display_name="conformance-receiver")
+
+    # Let announces settle on all sides. The sender needs the
+    # receiver's delivery announce so Identity.recall succeeds in
+    # lxmf_send_*. The propagation path convergence, if requested,
+    # needs the lxmd announce to traverse LocalClientInterface ->
+    # LocalServerInterface -> TCPServerInterface -> both clients, so
+    # give it a generous window.
+    time.sleep(_ANNOUNCE_PROPAGATION_SEC)
+
+    # Sender must know the receiver's delivery destination.
+    assert sender.poll_path(
+        receiver.delivery_dest_hash, timeout_ms=_SYNC_TIMEOUT_MS
+    ), (
+        f"{sender.role_label} did not learn a path to "
+        f"{receiver.role_label}'s delivery destination "
+        f"({receiver.delivery_dest_hash.hex()}) within "
+        f"{_SYNC_TIMEOUT_MS}ms; topology didn't converge."
+    )
+
+    # Opportunistic isn't 100% symmetric — the sender emits a delivery
+    # packet addressed to the receiver, which doesn't require the
+    # receiver to have a reverse path. But DIRECT requires a link,
+    # which involves round-trips; and the direct/opportunistic tests
+    # share a fixture, so wait for a reverse path too. (For the
+    # propagation fixture, the receiver's reverse-path requirement is
+    # implicit in sync_inbound's link to the prop node; reference
+    # doesn't need the receiver to know about the sender directly.)
+    assert receiver.poll_path(
+        sender.delivery_dest_hash, timeout_ms=_SYNC_TIMEOUT_MS
+    ), (
+        f"{receiver.role_label} did not learn a path to "
+        f"{sender.role_label}'s delivery destination "
+        f"({sender.delivery_dest_hash.hex()}) within "
+        f"{_SYNC_TIMEOUT_MS}ms; topology didn't converge."
+    )
+
+    for h in extra_path_hashes:
+        assert sender.poll_path(h, timeout_ms=_SYNC_TIMEOUT_MS), (
+            f"{sender.role_label} did not learn a path to "
+            f"{h.hex()} within {_SYNC_TIMEOUT_MS}ms."
+        )
+        assert receiver.poll_path(h, timeout_ms=_SYNC_TIMEOUT_MS), (
+            f"{receiver.role_label} did not learn a path to "
+            f"{h.hex()} within {_SYNC_TIMEOUT_MS}ms."
+        )
 
 
 @pytest.fixture
@@ -464,54 +697,12 @@ def lxmf_3peer(lxmf_trio):
             startup_timeout_sec=30.0,
         )
 
-        # Step 4: sender + receiver in-process LXMRouters. Each announces
-        # its delivery destination as part of lxmf_start. We STAGGER these:
-        # if both announces hit the middle peer in the same tick, RNS's
-        # Transport rate-limiter on the spawned TCPInterface for each
-        # client ends up queuing the second-direction rebroadcast, and in
-        # the specific sequence "sender announces then receiver announces
-        # in the same jiffy" the receiver's announce never reaches the
-        # sender's spawned interface queue before the rebroadcast retry
-        # limit fires. Empirically a 3s gap between the two lxmf_start
-        # calls is enough for the rebroadcast chain to complete cleanly;
-        # tighter gaps (<1s) leave sender without a path to receiver.
-        sender.lxmf_start(display_name="conformance-sender")
-        time.sleep(_INTER_ANNOUNCE_STAGGER_SEC)
-        receiver.lxmf_start(display_name="conformance-receiver")
-
-        # Step 5: let announces settle on all sides. The sender needs
-        # the receiver's delivery announce so Identity.recall succeeds
-        # in lxmf_send_propagated. The sender and receiver both need
-        # the propagation node's announce so set_outbound_propagation_node
-        # can find its identity for link establishment. The propagation
-        # node's announce has to traverse lxmd → LocalClientInterface →
-        # LocalServerInterface (wire bridge) → TCPServerInterface → both
-        # clients, so give it a generous window.
-        time.sleep(_ANNOUNCE_PROPAGATION_SEC)
-
-        # Guard: if the sender's path table never learned the receiver's
-        # delivery hash, the test below is going to fail for a
-        # meaningless reason (no path, not "propagation didn't work").
-        # Surface this explicitly so the failure diagnosis is crisp.
-        assert sender.poll_path(
-            receiver.delivery_dest_hash, timeout_ms=_SYNC_TIMEOUT_MS
-        ), (
-            f"{sender.role_label} did not learn a path to "
-            f"{receiver.role_label}'s delivery destination "
-            f"({receiver.delivery_dest_hash.hex()}) within "
-            f"{_SYNC_TIMEOUT_MS}ms; topology didn't converge."
-        )
-        assert sender.poll_path(
-            pn_hash, timeout_ms=_SYNC_TIMEOUT_MS
-        ), (
-            f"{sender.role_label} did not learn a path to the "
-            f"propagation node ({pn_hash.hex()}) within {_SYNC_TIMEOUT_MS}ms."
-        )
-        assert receiver.poll_path(
-            pn_hash, timeout_ms=_SYNC_TIMEOUT_MS
-        ), (
-            f"{receiver.role_label} did not learn a path to the "
-            f"propagation node ({pn_hash.hex()}) within {_SYNC_TIMEOUT_MS}ms."
+        # Steps 4-5: endpoint LXMRouter startup + announce + path
+        # convergence. Shared with lxmf_transport_3peer. Propagation
+        # needs BOTH endpoints to know the prop-node hash; pass it as
+        # an extra wait target.
+        _start_lxmf_peers_and_wait_for_paths(
+            sender, receiver, extra_path_hashes=(pn_hash,)
         )
 
         # Step 6-7: point sender + receiver at the propagation node.
@@ -521,6 +712,95 @@ def lxmf_3peer(lxmf_trio):
         yield sender, prop_node, receiver
     finally:
         for peer in (sender, prop_node, receiver):
+            try:
+                peer.stop()
+            except Exception:
+                pass
+        for b in bridges:
+            try:
+                b.close()
+            except Exception:
+                pass
+
+
+@pytest.fixture
+def lxmf_transport_3peer(lxmf_trio):
+    """Three bridge subprocesses wired up as sender → transport → receiver
+    with the middle peer acting as a plain RNS transport (no lxmd, no
+    propagation node). Exercises OPPORTUNISTIC and DIRECT delivery.
+
+    Topology:
+
+        sender (TCPClient)                 receiver (TCPClient)
+               \\                                  /
+                `----> transport (TCPServer) <---'
+                       enable_transport=true
+
+    The middle peer doesn't run an LXMRouter of its own — it's JUST a
+    packet mover. Any delivery between sender and receiver flows
+    through its Transport layer, exactly like Columba traffic crossing
+    an rnsd transport hop to reach Sideband.
+
+    Setup sequence:
+      1. transport brings up TCPServer (share_instance=False, plain
+         transport-mode RNS).
+      2. sender + receiver bring up TCPClients targeting that port.
+      3. sender.lxmf_start, receiver.lxmf_start (staggered) — each
+         attaches an in-process LXMRouter and announces its delivery
+         destination.
+      4. Wait for paths between endpoints to converge.
+
+    Yields (sender, receiver) — the middle peer is NOT yielded because
+    the opportunistic/direct tests don't assert on it (unlike the
+    propagation fixture, which yields prop_node for stored-message
+    count assertions). The transport peer still exists inside the
+    fixture scope and is torn down in the finalizer.
+    """
+    sender_impl, middle_impl, receiver_impl = lxmf_trio
+
+    # Transport fixture uses a plain Python reference middle. If the
+    # parametrization hands us anything else, fail loud — a follow-up
+    # PR that widens this would need to extend the resolver, not just
+    # sneak a different impl label past this guard.
+    if middle_impl != "reference":
+        pytest.fail(
+            f"lxmf_transport_3peer fixture only supports "
+            f"middle_impl='reference', got {middle_impl!r}."
+        )
+
+    bridges = [
+        BridgeClient(
+            _resolve_command_for_trio(sender_impl),
+            env=_env_for(sender_impl),
+        ),
+        BridgeClient(
+            _resolve_command_for_trio("reference"),
+            env=_env_for("reference"),
+        ),
+        BridgeClient(
+            _resolve_command_for_trio(receiver_impl),
+            env=_env_for(receiver_impl),
+        ),
+    ]
+    sender = _LxmfPeer(bridges[0], role_label=f"sender({sender_impl})")
+    transport = _LxmfPeer(bridges[1], role_label=f"transport({middle_impl})")
+    receiver = _LxmfPeer(bridges[2], role_label=f"receiver({receiver_impl})")
+
+    try:
+        # Step 1-2: wire layer. Transport middle is a plain
+        # enable_transport=true RNS; no share_instance, no lxmd.
+        port = transport.start_tcp_server(share_instance=False)
+        sender.start_tcp_client(target_port=port)
+        receiver.start_tcp_client(target_port=port)
+        time.sleep(_SETTLE_SEC)
+
+        # Steps 3-4: endpoint LXMRouter startup + announce + path
+        # convergence. No extra hashes beyond the endpoints themselves.
+        _start_lxmf_peers_and_wait_for_paths(sender, receiver)
+
+        yield sender, receiver
+    finally:
+        for peer in (sender, transport, receiver):
             try:
                 peer.stop()
             except Exception:

--- a/tests/lxmf/test_direct.py
+++ b/tests/lxmf/test_direct.py
@@ -50,8 +50,10 @@ def _xfail_kotlin_receiver_multipacket_duplicate(lxmf_trio):
 
     Tracked in https://github.com/torlando-tech/LXMF-kt/issues/8.
     Matches the loose-xfail pattern from tests/wire/test_link_multihop.py
-    (_xfail_kotlin_receiver_multihop) — GitHub issue tracks the fix,
-    XFAIL flips to XPASS when it lands.
+    (_xfail_kotlin_receiver_multihop). GitHub issue tracks the fix;
+    once closed, remove the pytest.xfail() call manually so the test
+    runs as a regular assertion again. (In-body pytest.xfail() raises
+    XFailed unconditionally, so there's no automatic XPASS flip.)
     """
     _sender, _middle, receiver = lxmf_trio
     if receiver == "kotlin":
@@ -122,9 +124,10 @@ def test_direct_with_file_attachment_multipacket(lxmf_trio, lxmf_transport_3peer
     the canonical wire format that all LXMF impls agree on when
     encoding attachments for transport.
     """
-    # Gate the kotlin-receiver case on the duplicate-delivery bug
-    # BEFORE touching the fixture so the xfail cost doesn't include
-    # ~30s of fixture setup. Loose-xfail pattern matching
+    # Gate the kotlin-receiver case on the duplicate-delivery bug.
+    # Note: pytest resolves fixtures before the test body runs, so this
+    # call does not skip fixture setup — it only short-circuits the
+    # assertions below. Loose-xfail pattern matching
     # tests/wire/test_link_multihop.py.
     _xfail_kotlin_receiver_multipacket_duplicate(lxmf_trio)
 

--- a/tests/lxmf/test_direct.py
+++ b/tests/lxmf/test_direct.py
@@ -1,0 +1,190 @@
+"""LXMF DIRECT delivery — end-to-end conformance test.
+
+Direct delivery:
+  - sender opens a Link to the recipient's delivery destination
+  - content <= LINK_PACKET_MAX_CONTENT (~319 bytes) goes as a single
+    LINK packet
+  - larger payloads use a Resource for multi-packet chunked transfer
+    (same path as image / file attachments in Columba / Sideband)
+
+Topology: sender -> [plain transport] -> receiver. Same
+lxmf_transport_3peer fixture as test_opportunistic.
+
+Parametrized 4 ways via lxmf_trio: {reference, kotlin} x {reference,
+kotlin} for sender + receiver.
+"""
+
+import secrets
+
+import pytest
+
+
+# LXMF FIELD_FILE_ATTACHMENTS: key 5 per LXMF spec. Canonical wire shape
+# (see memory/lxmf-attachment-format-variance.md): list of 2-element
+# positional tuples, [[filename_str, data_bytes], ...]. This test
+# deliberately uses shape #1 from the memo — the format that actually
+# travels over the wire between Python LXMF / Sideband / Columba.
+_FIELD_FILE_ATTACHMENTS = 5
+_TITLE_TEXT = "Direct text test"
+_TITLE_FILE = "Direct file attachment test"
+
+# Payload size for the multi-packet attachment test. Must be > 319 bytes
+# (LINK_PACKET_MAX_CONTENT) so the message uses Resource transfer
+# instead of single-packet. 2 KiB comfortably exceeds that and matches
+# the "small image" class of attachments Columba handles. Deterministic
+# per test run via secrets.token_bytes so exact-bytes assertions work.
+_ATTACHMENT_SIZE_BYTES = 2048
+
+
+def _xfail_kotlin_receiver_multipacket_duplicate(lxmf_trio):
+    """Mark the test as expected-to-fail when Kotlin is the receiver in
+    a multi-packet (Resource) DIRECT delivery test.
+
+    Bug: LXMF-kt delivers the same LXMessage twice when it arrives via
+    the Resource path, because its inbound-link wiring fires both
+    link.setPacketCallback and link.setResourceConcludedCallback on
+    resource-based delivery, and the `transientId` dedup in
+    processInboundDelivery is perpetually no-op
+    (LXMessage.transientId is declared private-set but never assigned
+    on the unpack path — see LXMessage.kt:63, LXMRouter.kt:1368).
+
+    Tracked in https://github.com/torlando-tech/LXMF-kt/issues/8.
+    Matches the loose-xfail pattern from tests/wire/test_link_multihop.py
+    (_xfail_kotlin_receiver_multihop) — GitHub issue tracks the fix,
+    XFAIL flips to XPASS when it lands.
+    """
+    _sender, _middle, receiver = lxmf_trio
+    if receiver == "kotlin":
+        pytest.xfail(
+            "LXMF-kt receiver delivers multi-packet DIRECT LXMessage "
+            "twice — https://github.com/torlando-tech/LXMF-kt/issues/8"
+        )
+
+
+def test_direct_text_round_trip(lxmf_trio, lxmf_transport_3peer):
+    """Sender -> transport -> receiver, text-only direct-delivery
+    message. Mirrors the opportunistic text test but goes over a
+    link instead of a single packet. The content size is well under
+    the single-link-packet cap so no Resource is involved on this
+    case — we test the Resource path in
+    test_direct_with_file_attachment_multipacket below.
+    """
+    sender, receiver = lxmf_transport_3peer
+
+    content = f"direct text {secrets.token_hex(8)}"
+
+    message_hash = sender.send_direct(
+        recipient_delivery_dest_hash=receiver.delivery_dest_hash,
+        content=content,
+        title=_TITLE_TEXT,
+    )
+    assert message_hash, (
+        f"{sender.role_label}.send_direct returned empty message_hash; "
+        f"sender didn't finish packing the outbound LXMessage."
+    )
+
+    # Direct delivery requires link establishment (round-trip), so the
+    # settle budget is a bit longer than opportunistic. 30s is the same
+    # default as the wire-layer link tests.
+    inbox = receiver.wait_for_inbox_count(expected=1, timeout_s=30.0)
+
+    assert inbox[0]["content"] == content, (
+        f"content mismatch: got {inbox[0]['content']!r}, "
+        f"expected {content!r}"
+    )
+    assert inbox[0]["title"] == _TITLE_TEXT, (
+        f"title mismatch: got {inbox[0]['title']!r}, "
+        f"expected {_TITLE_TEXT!r}"
+    )
+    assert inbox[0]["source"] == sender.delivery_dest_hash.hex(), (
+        f"source mismatch: got {inbox[0]['source']!r}, "
+        f"expected {sender.delivery_dest_hash.hex()!r}"
+    )
+    assert inbox[0]["fields"] == {}, (
+        f"expected empty fields dict, got {inbox[0]['fields']!r}"
+    )
+
+
+def test_direct_with_file_attachment_multipacket(lxmf_trio, lxmf_transport_3peer):
+    """Send a FIELD_FILE_ATTACHMENTS payload big enough to trigger
+    Resource transfer. Asserts the exact filename + exact attachment
+    bytes land on the receiver.
+
+    This is the test that would catch the Columba FIELD_FILE_ATTACHMENTS
+    bugs described in memory/lxmf-attachment-format-variance.md:
+    if an impl mis-handles the 2-element positional tuple on unpack,
+    the payload either doesn't appear in the inbox fields at all or
+    the filename / bytes get swapped / truncated, and the exact-match
+    assertion below flips red.
+
+    Uses shape #1 from the attachment-variance memo:
+      [[filename_str, data_bytes], ...]
+    the canonical wire format that all LXMF impls agree on when
+    encoding attachments for transport.
+    """
+    # Gate the kotlin-receiver case on the duplicate-delivery bug
+    # BEFORE touching the fixture so the xfail cost doesn't include
+    # ~30s of fixture setup. Loose-xfail pattern matching
+    # tests/wire/test_link_multihop.py.
+    _xfail_kotlin_receiver_multipacket_duplicate(lxmf_trio)
+
+    sender, receiver = lxmf_transport_3peer
+
+    content = f"direct file {secrets.token_hex(4)}"
+    filename = f"conformance-{secrets.token_hex(4)}.bin"
+    attachment_bytes = secrets.token_bytes(_ATTACHMENT_SIZE_BYTES)
+
+    message_hash = sender.send_direct(
+        recipient_delivery_dest_hash=receiver.delivery_dest_hash,
+        content=content,
+        title=_TITLE_FILE,
+        fields={
+            # Tagged-dict shape — see _decode_field_value_from_params.
+            # List-of-lists at the outer level (attachments are
+            # positionally indexed), each inner list is
+            # [filename_str, data_bytes] with the bytes wrapped in
+            # the {"bytes": "<hex>"} tag.
+            str(_FIELD_FILE_ATTACHMENTS): [
+                [
+                    {"str": filename},
+                    {"bytes": attachment_bytes.hex()},
+                ],
+            ],
+        },
+    )
+    assert message_hash, (
+        f"{sender.role_label}.send_direct returned empty message_hash "
+        f"on multipacket attachment test."
+    )
+
+    # Resource transfer of 2 KiB over a fresh link on loopback is fast
+    # (<2s steady-state), but the link setup + fragment-carrier setup
+    # takes a few seconds. 45s is the same budget the wire-layer
+    # resource tests use.
+    inbox = receiver.wait_for_inbox_count(expected=1, timeout_s=45.0)
+
+    assert inbox[0]["content"] == content, (
+        f"content mismatch: got {inbox[0]['content']!r}, "
+        f"expected {content!r}"
+    )
+    assert inbox[0]["title"] == _TITLE_FILE, (
+        f"title mismatch: got {inbox[0]['title']!r}, "
+        f"expected {_TITLE_FILE!r}"
+    )
+    assert inbox[0]["source"] == sender.delivery_dest_hash.hex(), (
+        f"source mismatch: got {inbox[0]['source']!r}, "
+        f"expected {sender.delivery_dest_hash.hex()!r}"
+    )
+
+    # Exact-shape field check on FIELD_FILE_ATTACHMENTS.
+    # Serialization path (applied on both impls):
+    #   [[filename_str, data_bytes]]    native
+    #    -> [[filename_str, data_hex]]  after recursive hex-encode
+    expected_field = [[filename, attachment_bytes.hex()]]
+    assert inbox[0]["fields"] == {
+        str(_FIELD_FILE_ATTACHMENTS): expected_field
+    }, (
+        f"FIELD_FILE_ATTACHMENTS payload mismatch: "
+        f"got {inbox[0]['fields']!r}, "
+        f"expected {{{str(_FIELD_FILE_ATTACHMENTS)!r}: {expected_field!r}}}"
+    )

--- a/tests/lxmf/test_opportunistic.py
+++ b/tests/lxmf/test_opportunistic.py
@@ -1,0 +1,146 @@
+"""LXMF OPPORTUNISTIC delivery — end-to-end conformance test.
+
+Opportunistic delivery:
+  - single encrypted packet, unicast, no link, no propagation node
+  - capped at LXMF.LXMessage.ENCRYPTED_PACKET_MAX_CONTENT (~295 bytes of
+    content + fields combined on the Python reference; LXMF-kt uses the
+    same cap). Oversized content silently upgrades to DIRECT on both
+    impls — the bridge send commands reject up-front so the conformance
+    tests stay scoped to the single-packet case; an oversized-opportunistic
+    test would need to assert "silent upgrade happened" explicitly, which
+    is a separate class of test.
+
+Topology: sender -> [plain transport] -> receiver. The middle peer is
+JUST an RNS transport (enable_transport=true); no lxmd, no LXMRouter of
+its own. Sender submits the message via its in-process LXMRouter; the
+delivery packet hops through the transport to the receiver's RNS, which
+decrypts it and fires the receiver's delivery callback.
+
+Parametrized over the cartesian product of {reference, kotlin} for
+sender + receiver — 4 trios total with --impl=kotlin. Mirrors the
+propagation-test pattern.
+"""
+
+import secrets
+
+import pytest
+
+
+# LXMF field key for images. FIELD_IMAGE = 6 per LXMF spec (see
+# LXMF/Fields.py in the Python reference). Values are a 2-element
+# positional list: [format_str, data_bytes].
+_FIELD_IMAGE = 6
+_TITLE_TEXT = "Opportunistic text test"
+_TITLE_IMAGE = "Opportunistic image test"
+
+
+def test_opportunistic_text_round_trip(lxmf_trio, lxmf_transport_3peer):
+    """Sender -> plain transport -> receiver, text-only opportunistic
+    message. Three tight assertions: (1) send returns a message hash,
+    (2) receiver's inbox is exactly length 1 after the delivery
+    callback fires, (3) content / title / source match the sender
+    exactly.
+    """
+    sender, receiver = lxmf_transport_3peer
+
+    # Random-tail content so a bug that reports cached / previous-run
+    # messages can't accidentally fake a pass. Short enough that total
+    # content + msgpack framing stays under ENCRYPTED_PACKET_MAX_CONTENT
+    # (~295 bytes); the send command rejects up-front if we overflow.
+    content = f"opp text {secrets.token_hex(8)}"
+
+    message_hash = sender.send_opportunistic(
+        recipient_delivery_dest_hash=receiver.delivery_dest_hash,
+        content=content,
+        title=_TITLE_TEXT,
+    )
+    assert message_hash, (
+        f"{sender.role_label}.send_opportunistic returned empty "
+        f"message_hash; sender didn't finish packing the outbound "
+        f"LXMessage."
+    )
+
+    # wait_for_inbox_count drains + accumulates until count reaches 1,
+    # then lingers to catch duplicates. Tight equality, per feedback memo.
+    inbox = receiver.wait_for_inbox_count(expected=1, timeout_s=20.0)
+
+    assert inbox[0]["content"] == content, (
+        f"content mismatch: got {inbox[0]['content']!r}, "
+        f"expected {content!r}"
+    )
+    assert inbox[0]["title"] == _TITLE_TEXT, (
+        f"title mismatch: got {inbox[0]['title']!r}, "
+        f"expected {_TITLE_TEXT!r}"
+    )
+    assert inbox[0]["source"] == sender.delivery_dest_hash.hex(), (
+        f"source mismatch: got {inbox[0]['source']!r}, "
+        f"expected {sender.delivery_dest_hash.hex()!r}"
+    )
+    # Fields should be empty dict — no fields were sent.
+    assert inbox[0]["fields"] == {}, (
+        f"expected empty fields dict, got {inbox[0]['fields']!r}"
+    )
+
+
+def test_opportunistic_with_image_field(lxmf_trio, lxmf_transport_3peer):
+    """Send a short text message with a FIELD_IMAGE attached. Asserts
+    exact field payload on receipt.
+
+    Field shape: FIELD_IMAGE (key = 6) is a 2-element positional list
+    [format_str, data_bytes]. Mirrors the canonical Python-LXMF wire
+    shape and the lxmf-kt side serialization. Kept small so the whole
+    packed message still fits in a single opportunistic packet.
+    """
+    sender, receiver = lxmf_transport_3peer
+
+    content = f"opp image {secrets.token_hex(4)}"
+    # ~64 bytes of "image" — synthetic, deterministic, and small enough
+    # to keep the packed message under ENCRYPTED_PACKET_MAX_CONTENT
+    # after accounting for msgpack field framing + stamp overhead.
+    image_bytes = secrets.token_bytes(64)
+    image_format = "jpg"
+
+    message_hash = sender.send_opportunistic(
+        recipient_delivery_dest_hash=receiver.delivery_dest_hash,
+        content=content,
+        title=_TITLE_IMAGE,
+        fields={
+            # Field values use the tagged shape — see
+            # _decode_field_value_from_params in lxmf_bridge.py and
+            # lxmfFieldValueFromJson in Lxmf.kt.
+            str(_FIELD_IMAGE): [
+                {"str": image_format},
+                {"bytes": image_bytes.hex()},
+            ],
+        },
+    )
+    assert message_hash, (
+        f"{sender.role_label}.send_opportunistic returned empty "
+        f"message_hash on image-field test."
+    )
+
+    inbox = receiver.wait_for_inbox_count(expected=1, timeout_s=20.0)
+
+    assert inbox[0]["content"] == content, (
+        f"content mismatch: got {inbox[0]['content']!r}, "
+        f"expected {content!r}"
+    )
+    assert inbox[0]["title"] == _TITLE_IMAGE, (
+        f"title mismatch: got {inbox[0]['title']!r}, "
+        f"expected {_TITLE_IMAGE!r}"
+    )
+    assert inbox[0]["source"] == sender.delivery_dest_hash.hex(), (
+        f"source mismatch: got {inbox[0]['source']!r}, "
+        f"expected {sender.delivery_dest_hash.hex()!r}"
+    )
+
+    # Exact-shape field check. The bridge serialises:
+    #   - top-level key as the int converted to str ("6")
+    #   - value as a 2-element list [format_str, data_hex]
+    #     (bytes are hex-encoded at every nesting level; see the
+    #     _encode_field_value_for_inbox / lxmfFieldValueToJson pair)
+    expected_field = [image_format, image_bytes.hex()]
+    assert inbox[0]["fields"] == {str(_FIELD_IMAGE): expected_field}, (
+        f"FIELD_IMAGE payload mismatch: got {inbox[0]['fields']!r}, "
+        f"expected {{{str(_FIELD_IMAGE)!r}: {expected_field!r}}}"
+    )


### PR DESCRIPTION
## Summary

Extends the LXMF conformance layer beyond propagation. Adds a `lxmf_transport_3peer` fixture (sender -> plain transport -> receiver, NO lxmd) and 4 new tests covering OPPORTUNISTIC and DIRECT delivery.

- `test_opportunistic_text_round_trip` + `test_opportunistic_with_image_field` - single-packet unicast, no link.
- `test_direct_text_round_trip` + `test_direct_with_file_attachment_multipacket` - link-based delivery, with the multi-packet test exercising the Resource path (the same path Columba / Sideband use for attachments).

Each test runs across 4 parametrizations (`{reference, kotlin} x {reference, kotlin}` on sender/receiver; middle always reference). Total: 16 new tests + 4 existing propagation = 20 cases.

Companion: https://github.com/torlando-tech/reticulum-kt/pull/44 adds the matching Kotlin bridge commands.

## Results

- 18/20 pass against the Kotlin bridge
- 2/20 xfail (kotlin-receiver multi-packet DIRECT) with a filed upstream bug: https://github.com/torlando-tech/LXMF-kt/issues/8 (double-delivery on Resource-based incoming; LXMessage.transientId is declared but never assigned on the unpack path, so the dedup guard is perpetually no-op)

Tight assertions throughout per the feedback memo: exact inbox counts, exact content/title/source/fields equality, exact payload bytes on the attachment test.

## Stacked on

#9 (Add LXMF propagation conformance suite MVP). Rebase if #9 merges first.

## Fixture factoring

Extracted endpoint setup (lxmf_start + staggered announce + path convergence) into `_start_lxmf_peers_and_wait_for_paths` so both the propagation fixture (uses lxmd) and the new transport fixture (plain transport) share the core sequencing without copy-paste. Also added a reverse-path assertion so the DIRECT tests' link-establishment can succeed.

## Attachment field shape

Uses the canonical positional wire format `[[filename_str, data_bytes]]` per [memory/lxmf-attachment-format-variance.md](/.claude/projects/-home-tyler-repos-public-columba/memory/lxmf-attachment-format-variance.md). Bytes inside field values are hex-encoded at every nesting level via the new recursive serialiser on both impls.

## Test plan

- [x] `cd reticulum-conformance && CONFORMANCE_BRIDGE_CMD=\"java -jar …/ConformanceBridge.jar\" python3 -m pytest tests/lxmf/ --impl=kotlin -v` emits 20 tests, 18 passed, 2 xfailed (4:49 wall).
- [x] No regressions on the pre-existing 4 propagation tests.
- [x] Both reference-only combos pass on every test - the baseline is intact.
- [x] Field serialisation round-trips match across impls (hex-encoded at all nesting levels; no ByteArray leak to JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)