### PR TITLE
Rename reticulum-swift-lib → reticulum-swift in default paths

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ from bridge_client import BridgeClient
 # Scheduled for removal once downstream CI migrates to the per-impl vars.
 BRIDGE_COMMANDS = {
     "reference": "python3 {root}/reference/bridge_server.py",
-    "swift": "{root}/../reticulum-swift-lib/.build/release/ConformanceBridge",
+    "swift": "{root}/../reticulum-swift/.build/release/ConformanceBridge",
     "kotlin": "java -jar {root}/../reticulum-kt/conformance-bridge/build/libs/ConformanceBridge.jar",
 }
 

--- a/impls/swift/Package.swift
+++ b/impls/swift/Package.swift
@@ -5,13 +5,13 @@ let package = Package(
     name: "SwiftBridge",
     platforms: [.macOS(.v13)],
     dependencies: [
-        .package(path: "../../../reticulum-swift-lib"),
+        .package(path: "../../../reticulum-swift"),
     ],
     targets: [
         .executableTarget(
             name: "SwiftBridge",
             dependencies: [
-                .product(name: "ReticulumSwift", package: "reticulum-swift-lib"),
+                .product(name: "ReticulumSwift", package: "reticulum-swift"),
             ]
         )
     ]

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -30,7 +30,7 @@ def peer_cmd(request):
         return cmd
     # Try auto-detect Swift PipePeer
     home = os.path.expanduser("~")
-    swift_peer = os.path.join(home, "repos/reticulum-swift-lib/.build/release/PipePeer")
+    swift_peer = os.path.join(home, "repos/reticulum-swift/.build/release/PipePeer")
     if os.path.exists(swift_peer):
         return swift_peer
     pytest.skip("No pipe peer binary found. Build with: swift build -c release --product PipePeer")

--- a/integration/test_announce_mode_pipe.py
+++ b/integration/test_announce_mode_pipe.py
@@ -54,7 +54,7 @@ def target_cmd(request):
     if cmd:
         return cmd
     home = os.path.expanduser("~")
-    swift_peer = os.path.join(home, "repos/reticulum-swift-lib/.build/release/PipePeer")
+    swift_peer = os.path.join(home, "repos/reticulum-swift/.build/release/PipePeer")
     if os.path.exists(swift_peer):
         return swift_peer
     return None  # Python-only fallback

--- a/integration/test_path_discovery_pipe.py
+++ b/integration/test_path_discovery_pipe.py
@@ -55,7 +55,7 @@ def target_cmd(request):
     if cmd:
         return cmd
     home = os.path.expanduser("~")
-    swift_peer = os.path.join(home, "repos/reticulum-swift-lib/.build/release/PipePeer")
+    swift_peer = os.path.join(home, "repos/reticulum-swift/.build/release/PipePeer")
     if os.path.exists(swift_peer):
         return swift_peer
     return None

--- a/integration/test_path_request_pipe.py
+++ b/integration/test_path_request_pipe.py
@@ -43,7 +43,7 @@ def target_cmd(request):
     if cmd:
         return cmd
     home = os.path.expanduser("~")
-    swift_peer = os.path.join(home, "repos/reticulum-swift-lib/.build/release/PipePeer")
+    swift_peer = os.path.join(home, "repos/reticulum-swift/.build/release/PipePeer")
     if os.path.exists(swift_peer):
         return swift_peer
     return None


### PR DESCRIPTION
## Summary
The Swift clone was renamed upstream (the repo is now \`github.com/torlando-tech/reticulum-swift\`, no \`-lib\` suffix). This PR updates the five fallback paths in conftest/integration fixtures so auto-discovery of the locally-built bridges resolves with current naming.

## Files changed
- \`conftest.py\` — default \`BRIDGE_COMMANDS["swift"]\`
- \`integration/conftest.py\` — \`peer_cmd\` auto-detect fallback
- \`integration/test_path_request_pipe.py\` — \`target_cmd\` fallback
- \`integration/test_announce_mode_pipe.py\` — same
- \`integration/test_path_discovery_pipe.py\` — same

## Impact
- Per-impl env overrides (\`CONFORMANCE_SWIFT_BRIDGE_CMD\`, \`--peer-cmd\`) are unchanged and still take precedence — this only affects the fallback used when nothing is set
- The reference implementation path is unchanged
- Kotlin paths are unchanged

## Broader design note (not in this PR)

Hardcoding \`../reticulum-swift\` into the shared suite assumes a specific sibling layout — which is what confused downstream users in the first place. A follow-up could drop the defaults entirely and require \`CONFORMANCE_<IMPL>_BRIDGE_CMD\` / \`--peer-cmd\` for anything non-reference, so the suite doesn't carry opinions about how consumers lay out their repos. Happy to open that separately if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)