### PR TITLE
Remove all stale Kotlin-receiver / Kotlin-transport xfails

### DIFF
--- a/tests/wire/test_link_multihop.py
+++ b/tests/wire/test_link_multihop.py
@@ -42,26 +42,6 @@ Kotlin-sender triples are the diagnostic targets.
 import secrets
 import time
 
-import pytest
-
-
-def _xfail_kotlin_receiver_multihop(wire_trio, reason_suffix=""):
-    """Mark the test as expected-to-fail when Kotlin is the receiver in a
-    multi-hop link topology.
-
-    Under burst transmission (multiple link data packets in rapid
-    succession), reticulum-kt's Link-inbound handler currently loses
-    packets (e.g., 4/5 arrive). This is a separate bug from the
-    sender-side HEADER_2 wrapping issue this test's primary variant
-    targets, and has not been fixed here.
-    """
-    _sender, _transport, receiver = wire_trio
-    if receiver == "kotlin":
-        pytest.xfail(
-            f"reticulum-kt Link-inbound packet loss on multi-hop receive "
-            f"(separate from the sender-side fix){reason_suffix}"
-        )
-
 
 # Allow generous time budgets — link establishment involves multiple
 # round-trips plus the default RNS handshake timing (PATHFINDER + link
@@ -142,7 +122,6 @@ def test_link_data_reaches_receiver_multihop(wire_trio, wire_3peer):
     receiver's link packet callback never fires. link_poll then
     returns empty.
     """
-    _xfail_kotlin_receiver_multihop(wire_trio)
     sender, transport, receiver, dest_hash = _setup_three_peer_topology(wire_3peer)
 
     link_id = sender.link_open(
@@ -184,7 +163,6 @@ def test_link_data_roundtrip_multiple_packets(wire_trio, wire_3peer):
     gets routed correctly (e.g. if a fix only updated the first TX but
     not later ones via an outdated path cache entry).
     """
-    _xfail_kotlin_receiver_multihop(wire_trio, " under burst send")
     sender, transport, receiver, dest_hash = _setup_three_peer_topology(wire_3peer)
 
     link_id = sender.link_open(

--- a/tests/wire/test_path_discovery.py
+++ b/tests/wire/test_path_discovery.py
@@ -112,14 +112,6 @@ def _start_three_peer_topology(
 # ---------------------------------------------------------------------------
 
 
-_ISSUE_46_REASON = (
-    "reticulum-kt TCPServerInterface fans out inbound packets to all other "
-    "connected clients, so C's PR leaks to A and A generates a fresh announce "
-    "with a new random_hash that overwrites B's cached entry. "
-    "See https://github.com/torlando-tech/reticulum-kt/issues/46."
-)
-
-
 def test_path_response_reuses_cached_announce(wire_trio, wire_3peer):
     """When B (transport) answers a PR for a destination it has cached,
     the re-emitted announce MUST be the cached announce — identifiable
@@ -166,24 +158,11 @@ def test_path_response_reuses_cached_announce(wire_trio, wire_3peer):
     )
     time.sleep(_SETTLE_SEC)
 
-    # Sanity: C must not have learned about A yet. On Python, B does
-    # not spontaneously retransmit cached announces on new connections,
-    # so this holds. On Kotlin, B's TCPServerInterface fans out every
-    # announce received from any peer to every other peer — the
-    # `sender->kotlin-server->receiver` topology may leak A's original
-    # announce to C on connect, which would short-circuit this test.
-    # We only assert this precondition AFTER the positive-side setup
-    # (A announced, B cached) so a vacuous-pass if xfail-below lands is
-    # impossible.
+    # Sanity: C must not have learned about A yet. Neither Python nor
+    # Kotlin spontaneously retransmits cached announces on new
+    # connections (Kotlin used to, via the TCPServerInterface fan-out
+    # behind reticulum-kt#46, fixed by torlando-tech/reticulum-kt#52).
     prior_entry = receiver.read_path_entry(dest_hash)
-
-    # reticulum-kt#46: Kotlin's TCPServerInterface fan-out leaks C's PR
-    # to A, triggering A to generate a fresh announce that overwrites
-    # B's cached entry. This violates the cached-packet invariant the
-    # test asserts. See issue for full trace + fix proposal.
-    _sender_impl, transport_impl, _receiver_impl = wire_trio
-    if transport_impl == "kotlin":
-        pytest.xfail(_ISSUE_46_REASON)
 
     assert prior_entry is None, (
         f"C ({receiver.role_label}) already has a path to "

--- a/tests/wire/test_resource_multihop.py
+++ b/tests/wire/test_resource_multihop.py
@@ -27,7 +27,6 @@ receiver_impl) triples the link-multihop test uses.
 import secrets
 import time
 
-import pytest
 
 
 _SETTLE_SEC = 1.5
@@ -37,19 +36,6 @@ _PATH_POLL_TIMEOUT_MS = 10000
 
 _APP_NAME = "resourceinterop"
 _ASPECTS = ["test"]
-
-
-def _xfail_kotlin_receiver(wire_trio, reason_suffix=""):
-    """Same follow-up bug as test_link_multihop's xfail helper, scoped
-    here to resource reassembly on Kotlin-receiver topologies.
-    """
-    _sender, _transport, receiver = wire_trio
-    if receiver == "kotlin":
-        pytest.xfail(
-            f"reticulum-kt link-inbound / resource-reassembly reliability on "
-            f"multi-hop receive (separate from sender-side fixes)"
-            f"{reason_suffix}"
-        )
 
 
 def _setup_three_peer_topology(wire_3peer, *, ifac: bool = False):
@@ -106,7 +92,6 @@ def test_small_resource_multihop(wire_trio, wire_3peer):
     one or more RESOURCE data packets → RESOURCE_PROOF. If this fails,
     the Resource API round-trip is broken even in the trivial case.
     """
-    _xfail_kotlin_receiver(wire_trio)
     sender, receiver, dest_hash, link_id = _setup_three_peer_topology(wire_3peer)
 
     payload = secrets.token_bytes(256)
@@ -130,7 +115,6 @@ def test_chunked_resource_multihop(wire_trio, wire_3peer):
     multiple link DATA packets. ~16 KB mirrors the size Columba was
     sending when the image bug surfaced (2 × 8175-byte chunks).
     """
-    _xfail_kotlin_receiver(wire_trio)
     sender, receiver, dest_hash, link_id = _setup_three_peer_topology(wire_3peer)
 
     payload = secrets.token_bytes(16 * 1024)
@@ -162,7 +146,6 @@ def test_chunked_resource_with_ifac_multihop(wire_trio, wire_3peer):
     This is the bug that shows up in production for Columba image
     sends.
     """
-    _xfail_kotlin_receiver(wire_trio, " with IFAC")
     sender, receiver, dest_hash, link_id = _setup_three_peer_topology(
         wire_3peer, ifac=True
     )
@@ -191,7 +174,6 @@ def test_large_resource_multihop(wire_trio, wire_3peer):
     ~8 KB MDU ≈ 32 packets, stress-tests back-to-back link DATA
     transmission + reassembly.
     """
-    _xfail_kotlin_receiver(wire_trio, " under large-resource burst")
     sender, receiver, dest_hash, link_id = _setup_three_peer_topology(wire_3peer)
 
     payload = secrets.token_bytes(256 * 1024)

--- a/tests/wire/test_resource_multihop.py
+++ b/tests/wire/test_resource_multihop.py
@@ -27,8 +27,6 @@ receiver_impl) triples the link-multihop test uses.
 import secrets
 import time
 
-
-
 _SETTLE_SEC = 1.5
 _LINK_TIMEOUT_MS = 15000
 _RESOURCE_TIMEOUT_MS = 30000


### PR DESCRIPTION
## Summary

Removes **all 28 stale `xfail` gates** in `tests/wire/`. The underlying reticulum-kt bugs that made these tests xfail-marked have all been fixed by [#52](https://github.com/torlando-tech/reticulum-kt/pull/52) (TCPServerInterface fan-out removal) and [#53](https://github.com/torlando-tech/reticulum-kt/pull/53) (Link.status=ACTIVE race), so the gates are now hiding work that's already done.

## What was xfail'd, why, and current state

| Test | Triples | Was blocked by | Status against current reticulum-kt main |
|---|---|---|---|
| `test_path_response_reuses_cached_announce` | 4 (transport=kotlin) | reticulum-kt#46 | All 8 triples PASS in isolation |
| `test_link_data_reaches_receiver_multihop` | 4 (receiver=kotlin) | "Kotlin Link-inbound packet loss on multi-hop receive" | PASS |
| `test_link_data_roundtrip_multiple_packets` | 4 (receiver=kotlin) | same | PASS in isolation; 1 occasional flake under full-suite load (residual reticulum-kt#42 first-packet-of-burst race surviving #53's fix) |
| `test_small_resource_multihop` | 4 (receiver=kotlin) | "Kotlin resource-reassembly reliability" | PASS |
| `test_chunked_resource_multihop` | 4 | same | PASS |
| `test_chunked_resource_with_ifac_multihop` | 4 | same | PASS |
| `test_large_resource_multihop` | 4 | same | PASS |

## Verification

Each file run separately against post-#52/#53 reticulum-kt (local conformance harness):

```
pytest tests/wire/test_path_discovery.py     ->   8 passed
pytest tests/wire/test_link_multihop.py      ->  24 passed
pytest tests/wire/test_resource_multihop.py  ->  40 passed (in isolation)
```

Combined-file run produced 131/132 passed, with the single failure being the residual #42 race on `kotlin->reference->kotlin` (sender-side first-packet-of-burst) — same signature, surviving in narrower form than before.

## On the residual flake

Leaving `test_link_data_roundtrip_multiple_packets[kotlin->reference->kotlin]` enabled despite its occasional flake is intentional. The race exists today, it's a known reticulum-kt#42 residual, and a flaky test gives signal — `xfail(strict=False)` would silently swallow it forever. If CI flakes on it post-merge, the right next step is finishing the #42 fix on the reticulum-kt side, not re-suppressing.

## Net diff

`-65 / +4` lines. Removes:
- `_ISSUE_46_REASON` constant + xfail call from `test_path_discovery.py`
- `_xfail_kotlin_receiver_multihop` helper + 2 call sites from `test_link_multihop.py`
- `_xfail_kotlin_receiver` helper + 4 call sites from `test_resource_multihop.py`
- Now-unused `import pytest` from `test_resource_multihop.py`

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._