### PR TITLE
Add DEFAULT_IFAC_SIZE to _HdlcPipe in three_node_session

### DIFF
--- a/integration/three_node_session.py
+++ b/integration/three_node_session.py
@@ -424,6 +424,18 @@ class ThreeNodeSession:
             FLAG = 0x7E
             ESC = 0x7D
             ESC_MASK = 0x20
+            # Required by RNS.Reticulum._add_interface (Reticulum.py:780),
+            # which reads `interface.DEFAULT_IFAC_SIZE` whenever no explicit
+            # `ifac_size` is passed. Every concrete RNS interface declares
+            # one (SerialInterface.py / AX25KISSInterface.py = 8;
+            # UDPInterface / BackboneInterface = 16). Without it,
+            # _add_interface raises AttributeError and Node B's setup in
+            # ThreeNodeSession aborts, cascading into "A should emit ready"
+            # failures in test_path_request_pipe.py because A's subprocess
+            # never sees the other end of the pipe come up. Match the
+            # serial-class default of 8 since this is a stdio pipe, not
+            # a UDP-style network interface.
+            DEFAULT_IFAC_SIZE = 8
 
             def __init__(self, iname, ipin, ipout, imode):
                 super().__init__()


### PR DESCRIPTION
## Summary

One-line fix for `integration/three_node_session.py` — the inline
`_HdlcPipe` class is missing the `DEFAULT_IFAC_SIZE` class attribute
that `RNS.Reticulum._add_interface` expects.

## Detail

Python RNS reads `interface.DEFAULT_IFAC_SIZE` at
`RNS/Reticulum.py:780` whenever no explicit `ifac_size` is passed:

```python
if ifac_size != None: interface.ifac_size = ifac_size
else:                 interface.ifac_size = interface.DEFAULT_IFAC_SIZE
```

Every concrete RNS interface class declares this:
- `SerialInterface.py:53` → `8`
- `AX25KISSInterface.py:70` → `8`
- `UDPInterface.py:42` → `16`
- `BackboneInterface.py:54` → `16`

The inline `_HdlcPipe(BaseInterface)` in `_make_hdlc_pipe` was missing
it, so every test that brings up an in-process Node B (every test in
`integration/test_path_request_pipe.py`) hits `AttributeError` when
calling `b_reticulum._add_interface(self.b_pipe_a, ...)`. Node B's
setup aborts, and Node A's subprocess never sees the other end of
its pipe come up — surfacing as the cascading "A should emit ready"
assertion failures.

Set to `8` (matching the serial-class default) since `_HdlcPipe` is
a stdio pipe between processes, not a UDP-style multicast interface.

## Test plan

- [x] `python3 -m pytest integration/test_path_request_pipe.py`

  Before this commit:
  ```
  2 failed, 1 error in ~75s
  ```

  After:
  ```
  3 passed in 4.93s
  ```

- [x] Other integration tests unaffected (they use the parallel
  `_StdioPipe` class in `pipe_session.py:166`, which already has
  `DEFAULT_IFAC_SIZE = 8`).

## Observed externally

`reticulum-swift` PR #10 surfaced this — that PR's wire-conformance
work means the suite gets through the conformance phase and reaches
the integration phase, where this harness bug becomes visible. With
this fix landed, that PR's CI goes fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)