### PR TITLE
Add DEFAULT_IFAC_SIZE to StreamPipeInterface in pipe_peer_local

### DIFF
--- a/integration/pipe_peer_local.py
+++ b/integration/pipe_peer_local.py
@@ -356,6 +356,14 @@ def _create_pipe_interface(RNS, pin, pout, name="StdioPipe"):
         FLAG = 0x7E
         ESC = 0x7D
         ESC_MASK = 0x20
+        # Required by RNS.Reticulum._add_interface (Reticulum.py:966).
+        # See the matching attribute on three_node_session._HdlcPipe.
+        # Without this, A's `_add_interface` call raises AttributeError
+        # silently before A reaches `emit({"type": "ready"})`, and the
+        # session-level "A should emit ready" assertion fails after a
+        # 20s timeout. Match the serial-class default of 8 since this
+        # is a stdio pipe, not a UDP-style network interface.
+        DEFAULT_IFAC_SIZE = 8
 
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
## Summary

Companion to #17. That PR added `DEFAULT_IFAC_SIZE = 8` to `_HdlcPipe`
in `three_node_session.py` (the inline class used by in-process
Node B). This PR adds the same attribute to the parallel inline class
`StreamPipeInterface` in `pipe_peer_local.py:355`, which every pipe-peer
subprocess (Node A always, Node C sometimes) instantiates.

## Detail

`pipe_peer_local.py` imports Python RNS via `PYTHON_RNS_PATH`
(`~/repos/Reticulum` by default; the GitHub Actions workflow points at
a fresh checkout of `markqvist/Reticulum`). Upstream RNS reads
`interface.DEFAULT_IFAC_SIZE` at `_add_interface` time
(`Reticulum.py:966`). Without this attribute on the interface class,
`_add_interface` raises `AttributeError` before the subprocess reaches
`emit({"type": "ready"})`, which surfaces in higher-level tests as
"A should emit ready" / "C should emit ready" assertion failures after
a 20s timeout.

I missed this in #17 because my local `~/repos/Reticulum` was on an
older commit where `_add_interface` had a literal `interface.ifac_size = 8`
fallback. Pulling master locally reproduced the CI failure exactly.

## Test plan

- [x] Pull upstream Reticulum master:
  ```
  cd ~/repos/Reticulum && git pull origin master
  ```
- [x] Run failing tests:
  ```
  python3 -m pytest integration/test_path_request_pipe.py
  ```

  Before this commit (with #17 already in main):
  ```
  FAILED ...TestPathRequestResponder::test_sut_responds_to_path_request_from_cache
  FAILED ...TestPathRequestRequester::test_sut_discovers_path_via_request
  FAILED ...TestPathRequestBothSUT::test_both_sut_path_request_roundtrip
  3 failed in ~95s
  ```

  After:
  ```
  3 passed in 4.93s
  ```

## Observed externally

`reticulum-swift` PR #10's CI was the canary — the wire-conformance
phase passes since that PR's fixes, the integration phase reaches
`test_path_request_pipe.py`, and CI fails on the same three tests.
With this PR landed those failures clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)