### PR TITLE
Add deterministic post-prove invariant test + nightly stress canary

### DIFF
--- a/.github/workflows/stress-multihop.yml
+++ b/.github/workflows/stress-multihop.yml
@@ -1,0 +1,104 @@
+name: Stress Multihop Flake Rate
+
+# Approach 3 from the post-#52/#53/#54 race investigation: a non-blocking
+# canary that runs the multihop link + resource suite N times to detect
+# regressions in flake rate. Doesn't catch a specific seam (Approach 1 /
+# tests/wire/test_link_post_prove_invariant.py does that for the post-prove
+# invariant), but catches "something else started racing" without us having
+# to predict what.
+#
+# The job is `continue-on-error: true` and gated to a label so it doesn't
+# block PRs — it produces a flake-rate count that maintainers can eyeball
+# in the workflow logs. Tracked baseline: ~3 of 5 full-suite runs flake
+# (60%) per reticulum-kt#56's stress data.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, labeled]
+  schedule:
+    # Nightly run so trends are visible without needing PR labels.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  stress:
+    # Only run on PRs when explicitly labeled, OR on schedule, OR manual.
+    # Avoids spending CI minutes on every PR push.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      contains(github.event.pull_request.labels.*.name, 'stress-test')
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true  # Non-blocking: this is a signal, not a gate.
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: reticulum-conformance
+
+      - uses: actions/checkout@v4
+        with:
+          repository: torlando-tech/reticulum-kt
+          path: reticulum-kt
+
+      - uses: actions/checkout@v4
+        with:
+          repository: markqvist/Reticulum
+          path: Reticulum
+
+      - uses: actions/checkout@v4
+        with:
+          repository: markqvist/LXMF
+          path: LXMF
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: pip install pytest pytest-repeat
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build Kotlin conformance bridge
+        working-directory: reticulum-kt
+        run: ./gradlew :conformance-bridge:shadowJar
+
+      - name: Stress run — multihop suite × 10
+        working-directory: reticulum-conformance
+        env:
+          CONFORMANCE_KOTLIN_BRIDGE_CMD: java -jar ${{ github.workspace }}/reticulum-kt/conformance-bridge/build/libs/ConformanceBridge.jar
+          PYTHON_RNS_PATH: ${{ github.workspace }}/Reticulum
+          PYTHON_LXMF_PATH: ${{ github.workspace }}/LXMF
+        run: |
+          set +e
+          fail_count=0
+          pass_count=0
+          for i in $(seq 1 10); do
+            echo "=== Stress run $i / 10 ==="
+            python3 -m pytest \
+              tests/wire/test_link_multihop.py \
+              tests/wire/test_resource_multihop.py \
+              --impl=kotlin -q --tb=line
+            if [ $? -eq 0 ]; then
+              pass_count=$((pass_count + 1))
+            else
+              fail_count=$((fail_count + 1))
+            fi
+          done
+          echo ""
+          echo "::notice::Stress multihop flake rate: $fail_count of 10 runs failed ($pass_count clean)"
+          # Exit 0 (continue-on-error doubles down): the value is the
+          # ::notice:: line, visible in the workflow summary.
+          exit 0

--- a/.github/workflows/stress-multihop.yml
+++ b/.github/workflows/stress-multihop.yml
@@ -39,19 +39,27 @@ jobs:
         with:
           path: reticulum-conformance
 
+      # External repos are intentionally floated against `main` (rather
+      # than a pinned SHA/tag) because the canary's purpose is to catch
+      # regressions surfacing from upstream HEADs — pinning would defeat
+      # that. If a breaking upstream commit makes the canary noisy, bump
+      # the `ref:` here to the last-known-good SHA and triage.
       - uses: actions/checkout@v4
         with:
           repository: torlando-tech/reticulum-kt
+          ref: main
           path: reticulum-kt
 
       - uses: actions/checkout@v4
         with:
           repository: markqvist/Reticulum
+          ref: master
           path: Reticulum
 
       - uses: actions/checkout@v4
         with:
           repository: markqvist/LXMF
+          ref: master
           path: LXMF
 
       - name: Set up JDK 21
@@ -66,7 +74,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install Python dependencies
-        run: pip install pytest pytest-repeat
+        run: pip install pytest
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4

--- a/reference/wire_tcp.py
+++ b/reference/wire_tcp.py
@@ -1185,5 +1185,11 @@ WIRE_COMMANDS = {
     "wire_resource_send": cmd_wire_resource_send,
     "wire_resource_poll": cmd_wire_resource_poll,
     "wire_get_received_packets": cmd_wire_get_received_packets,
+    "wire_set_race_inducer": lambda params: {
+        # Python reference doesn't have the race we're inducing. Accept the
+        # command but no-op so cross-impl tests can call it uniformly.
+        "seam": params.get("seam"),
+        "delay_ms": int(params.get("delay_ms", 0)),
+    },
     "wire_stop": cmd_wire_stop,
 }

--- a/tests/wire/conftest.py
+++ b/tests/wire/conftest.py
@@ -278,6 +278,26 @@ class _WirePeer:
         )
         return bytes.fromhex(resp["link_id"])
 
+    def set_race_inducer(self, seam: str, delay_ms: int):
+        """Set a test-only race-inducer hook in the production code under test.
+
+        Used to deterministically widen narrow race windows so a regression
+        at a specific seam fails reliably instead of intermittently. Currently
+        instrumented seams (Kotlin only — Python no-ops):
+
+          "post-prove" — sleeps in receiver-side validateRequest after
+                         link.prove() returns, to verify that all bookkeeping
+                         needed for inbound DATA dispatch has completed by the
+                         time prove() returns (the invariant fixed in #54).
+        """
+        assert self.handle, "start_* must be called first"
+        self.bridge.execute(
+            "wire_set_race_inducer",
+            handle=self.handle,
+            seam=seam,
+            delay_ms=int(delay_ms),
+        )
+
     def link_send(self, link_id: bytes, data: bytes):
         assert self.handle, "start_* must be called first"
         self.bridge.execute(

--- a/tests/wire/test_link_post_prove_invariant.py
+++ b/tests/wire/test_link_post_prove_invariant.py
@@ -1,0 +1,142 @@
+"""Deterministic regression test for the receiver-side post-prove invariant.
+
+Locks in the fix from reticulum-kt#54: by the time `link.prove()` returns
+on the receiver side, ALL bookkeeping required for inbound link DATA
+dispatch must already have happened. Specifically:
+
+- `Transport.registerLink(link)` must have added the link to `activeLinks`
+  before LRPROOF goes on the wire, so any DATA arriving immediately after
+  the sender sees ACTIVE finds the link in `activeLinks` and is dispatched
+  to `Link.receive(packet)` instead of being dropped at Transport's
+  `processData` lookup.
+
+- All other inbound-dispatch dependencies (attachedInterfaceHash, link
+  encryption keys via handshake(), etc.) must likewise be ready.
+
+Methodology: the receiver bridge sets a test-only race inducer that
+sleeps for `_INDUCER_DELAY_MS` immediately AFTER `link.prove()` returns
+(but inside `validateRequest`, before any further bookkeeping could
+happen). The sender then opens a link and sends DATA immediately. While
+the receiver is "stuck" in the post-prove sleep, the sender's first DATA
+packet arrives at the receiver. If all dispatch dependencies are
+satisfied by the moment prove() returns, the DATA is delivered. If any
+required setup happens AFTER prove(), the DATA is dropped.
+
+Pre-#54 (registerLink after prove): test fails deterministically.
+Post-#54 (registerLink before prove): test passes deterministically.
+
+The test is parameterized on (sender_impl, transport_impl) but pins the
+receiver to kotlin — the inducer is Kotlin-only, so verifying the
+invariant on a Python receiver would be vacuous (no inducer fires).
+"""
+
+import secrets
+import time
+
+
+_APP_NAME = "linkpostprove"
+_ASPECTS = ["test"]
+_SETTLE_SEC = 1.5
+_LINK_TIMEOUT_MS = 15000
+_POLL_TIMEOUT_MS = 10000
+_INDUCER_DELAY_MS = 2000
+_POST_INDUCER_BUFFER_MS = 3000
+
+
+def _setup_three_peer_topology(wire_3peer):
+    """Mirrors test_link_multihop._setup_three_peer_topology — duplicated
+    here rather than imported because pytest test files in the same dir
+    don't import each other cleanly without conftest plumbing.
+    """
+    sender, transport, receiver = wire_3peer
+    port = transport.start_tcp_server(network_name="", passphrase="")
+    receiver.start_tcp_client(
+        network_name="", passphrase="", target_host="127.0.0.1", target_port=port
+    )
+    sender.start_tcp_client(
+        network_name="", passphrase="", target_host="127.0.0.1", target_port=port
+    )
+    time.sleep(_SETTLE_SEC)
+    dest_hash = receiver.listen(app_name=_APP_NAME, aspects=_ASPECTS)
+    assert sender.poll_path(dest_hash, timeout_ms=_POLL_TIMEOUT_MS), (
+        f"{sender.role_label} did not learn a path to "
+        f"{receiver.role_label}'s destination via {transport.role_label}."
+    )
+    return sender, transport, receiver, dest_hash
+
+
+import pytest
+
+
+_RESIDUAL_BUG_URL = "https://github.com/torlando-tech/reticulum-kt/issues/56"
+_RESIDUAL_BUG_REASON = (
+    "reticulum-kt#56 residual: destination.linkEstablished callback fires "
+    "in thread(isDaemon = true) at Link.kt:1888-1911 instead of "
+    "synchronously from rttPacket. Read loop processes DATA before the "
+    "daemon thread wires link.setPacketCallback, so DATA is silently "
+    "dropped. Reproduces 5/5 with a 2s inducer. See: " + _RESIDUAL_BUG_URL
+)
+
+
+@pytest.mark.xfail(strict=False, reason=_RESIDUAL_BUG_REASON)
+def test_first_data_arrives_during_induced_post_prove_window(wire_trio, wire_3peer):
+    # Inducer is Kotlin-only — Python receiver no-ops the bridge command,
+    # so verifying the invariant on a Python receiver would be vacuous.
+    _sender_impl, _transport_impl, receiver_impl = wire_trio
+    if receiver_impl != "kotlin":
+        pytest.skip("post-prove inducer is Kotlin-only; skipping non-kotlin receiver")
+    """Sender sends DATA immediately after link establishment; receiver is
+    stuck in a 500ms post-prove sleep. The DATA must still be delivered.
+
+    Regression test for reticulum-kt#54. Pre-fix, registerLink ran AFTER
+    prove() — so the link was not in activeLinks during the induced window
+    and the DATA was dropped. Post-fix, registerLink runs BEFORE prove() —
+    so the link is in activeLinks before the LRPROOF leaves the wire and
+    the DATA is dispatched correctly even though validateRequest is still
+    sleeping.
+    """
+    # Standard 3-peer setup: sender announces a path to receiver via
+    # transport, sender opens a link to receiver's destination.
+    sender, transport, receiver, dest_hash = _setup_three_peer_topology(
+        wire_3peer
+    )
+
+    # Set the inducer AFTER the bridges are up but BEFORE link establishment.
+    # The static is process-wide on the bridge side, so any link established
+    # after this point will hit the sleep at the post-prove seam.
+    receiver.set_race_inducer(seam="post-prove", delay_ms=_INDUCER_DELAY_MS)
+
+    try:
+
+        link_id = sender.link_open(
+            dest_hash,
+            app_name=_APP_NAME,
+            aspects=_ASPECTS,
+            timeout_ms=_LINK_TIMEOUT_MS + _INDUCER_DELAY_MS,
+        )
+
+        # Send the first DATA packet IMMEDIATELY after link_open returns.
+        # On the sender side, link_open returns when status==ACTIVE, which
+        # happens upon LRPROOF receipt. At that exact moment the receiver
+        # is mid-sleep in validateRequest's post-prove inducer.
+        payload = secrets.token_bytes(32)
+        sender.link_send(link_id, payload)
+
+        # Wait long enough for the inducer to release plus the round trip
+        # for the DATA to be observed by the receiver's link callback.
+        received = receiver.link_poll(
+            dest_hash,
+            timeout_ms=_INDUCER_DELAY_MS + _POST_INDUCER_BUFFER_MS,
+        )
+
+        assert received == [payload], (
+            f"{receiver.role_label} did not receive the DATA packet that "
+            f"arrived during the induced {_INDUCER_DELAY_MS}ms post-prove "
+            f"window. Got {len(received)} packet(s). This means some "
+            f"bookkeeping needed for inbound link-DATA dispatch was deferred "
+            f"to AFTER link.prove() returned, violating the invariant fixed "
+            f"in reticulum-kt#54."
+        )
+    finally:
+        # Reset inducer so subsequent tests run with default behaviour.
+        receiver.set_race_inducer(seam="post-prove", delay_ms=0)

--- a/tests/wire/test_link_post_prove_invariant.py
+++ b/tests/wire/test_link_post_prove_invariant.py
@@ -33,6 +33,8 @@ invariant on a Python receiver would be vacuous (no inducer fires).
 import secrets
 import time
 
+import pytest
+
 
 _APP_NAME = "linkpostprove"
 _ASPECTS = ["test"]
@@ -65,9 +67,6 @@ def _setup_three_peer_topology(wire_3peer):
     return sender, transport, receiver, dest_hash
 
 
-import pytest
-
-
 _RESIDUAL_BUG_URL = "https://github.com/torlando-tech/reticulum-kt/issues/56"
 _RESIDUAL_BUG_REASON = (
     "reticulum-kt#56 residual: destination.linkEstablished callback fires "
@@ -80,13 +79,8 @@ _RESIDUAL_BUG_REASON = (
 
 @pytest.mark.xfail(strict=False, reason=_RESIDUAL_BUG_REASON)
 def test_first_data_arrives_during_induced_post_prove_window(wire_trio, wire_3peer):
-    # Inducer is Kotlin-only — Python receiver no-ops the bridge command,
-    # so verifying the invariant on a Python receiver would be vacuous.
-    _sender_impl, _transport_impl, receiver_impl = wire_trio
-    if receiver_impl != "kotlin":
-        pytest.skip("post-prove inducer is Kotlin-only; skipping non-kotlin receiver")
     """Sender sends DATA immediately after link establishment; receiver is
-    stuck in a 500ms post-prove sleep. The DATA must still be delivered.
+    stuck in a 2000ms post-prove sleep. The DATA must still be delivered.
 
     Regression test for reticulum-kt#54. Pre-fix, registerLink ran AFTER
     prove() — so the link was not in activeLinks during the induced window
@@ -95,6 +89,11 @@ def test_first_data_arrives_during_induced_post_prove_window(wire_trio, wire_3pe
     the DATA is dispatched correctly even though validateRequest is still
     sleeping.
     """
+    # Inducer is Kotlin-only — Python receiver no-ops the bridge command,
+    # so verifying the invariant on a Python receiver would be vacuous.
+    _sender_impl, _transport_impl, receiver_impl = wire_trio
+    if receiver_impl != "kotlin":
+        pytest.skip("post-prove inducer is Kotlin-only; skipping non-kotlin receiver")
     # Standard 3-peer setup: sender announces a path to receiver via
     # transport, sender opens a link to receiver's destination.
     sender, transport, receiver, dest_hash = _setup_three_peer_topology(


### PR DESCRIPTION
## Summary

Two complementary additions for the multi-hop link race investigation documented in [reticulum-kt#56](https://github.com/torlando-tech/reticulum-kt/issues/56):

### Approach 1 — Deterministic regression test

`tests/wire/test_link_post_prove_invariant.py` uses the new race-inducer hook in [reticulum-kt#57](https://github.com/torlando-tech/reticulum-kt/pull/57) to widen the post-prove window on the receiver, then sends DATA from the sender as soon as `link_open` returns ACTIVE. Asserts the DATA is delivered to the receiver's link callback even though `validateRequest` is mid-sleep.

Pre-#54 this would have caught the original `registerLink`-after-`prove` ordering bug. With #54 in place but the residual #56 daemon-thread callback-wiring bug active, the test exposes the deeper invariant violation: `destination.linkEstablished` fires in `thread(isDaemon = true)` at `Link.kt:1888-1911` instead of synchronously from `rttPacket`, so the first DATA arriving after LRRTT can race the daemon thread and miss the user's packet callback.

Currently marked `xfail(strict=False)` since #56 is unfixed. When fixed, flip to `strict=True` (or drop the marker) so future regressions fail the build.

### Approach 3 — Nightly stress canary

`.github/workflows/stress-multihop.yml` is a non-blocking workflow that runs the multihop suite 10 times and reports flake count via `::notice::`. Triggered nightly, on the `stress-test` PR label, or manually. Doesn't block PRs — it's signal, not gate. Catches "something started racing" without needing a test author to predict what.

## Cross-impl support

`_WirePeer.set_race_inducer` calls the bridge's new `wire_set_race_inducer` command. Python reference gracefully no-ops the command since it doesn't have the bug.

## Depends on

[reticulum-kt#57](https://github.com/torlando-tech/reticulum-kt/pull/57) (race inducer hook). Conformance CI will fail until that lands and reticulum-kt main has the new bridge command.

Net diff: +272 lines / -0 across 4 files (1 new test, 1 new workflow, 1 conftest method, 1 Python bridge stub).

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._