### PR TITLE
Drop LXMF-kt#8 xfail — fixed by LXMF-kt v0.0.8

### DIFF
--- a/tests/lxmf/test_direct.py
+++ b/tests/lxmf/test_direct.py
@@ -16,7 +16,6 @@ kotlin} for sender + receiver.
 
 import secrets
 
-import pytest
 
 
 # LXMF FIELD_FILE_ATTACHMENTS: key 5 per LXMF spec. Canonical wire shape
@@ -36,31 +35,11 @@ _TITLE_FILE = "Direct file attachment test"
 _ATTACHMENT_SIZE_BYTES = 2048
 
 
-def _xfail_kotlin_receiver_multipacket_duplicate(lxmf_trio):
-    """Mark the test as expected-to-fail when Kotlin is the receiver in
-    a multi-packet (Resource) DIRECT delivery test.
-
-    Bug: LXMF-kt delivers the same LXMessage twice when it arrives via
-    the Resource path, because its inbound-link wiring fires both
-    link.setPacketCallback and link.setResourceConcludedCallback on
-    resource-based delivery, and the `transientId` dedup in
-    processInboundDelivery is perpetually no-op
-    (LXMessage.transientId is declared private-set but never assigned
-    on the unpack path — see LXMessage.kt:63, LXMRouter.kt:1368).
-
-    Tracked in https://github.com/torlando-tech/LXMF-kt/issues/8.
-    Matches the loose-xfail pattern from tests/wire/test_link_multihop.py
-    (_xfail_kotlin_receiver_multihop). GitHub issue tracks the fix;
-    once closed, remove the pytest.xfail() call manually so the test
-    runs as a regular assertion again. (In-body pytest.xfail() raises
-    XFailed unconditionally, so there's no automatic XPASS flip.)
-    """
-    _sender, _middle, receiver = lxmf_trio
-    if receiver == "kotlin":
-        pytest.xfail(
-            "LXMF-kt receiver delivers multi-packet DIRECT LXMessage "
-            "twice — https://github.com/torlando-tech/LXMF-kt/issues/8"
-        )
+# LXMF-kt#8 (DIRECT multi-packet double-delivery) was fixed by
+# LXMF-kt#14 + #16, included from v0.0.8 of the LXMF-kt artifact that
+# reticulum-kt's conformance-bridge consumes. The receiver=kotlin
+# variants of test_direct_with_file_attachment_multipacket below now
+# pass without the prior xfail gate.
 
 
 def test_direct_text_round_trip(lxmf_trio, lxmf_transport_3peer):
@@ -124,13 +103,6 @@ def test_direct_with_file_attachment_multipacket(lxmf_trio, lxmf_transport_3peer
     the canonical wire format that all LXMF impls agree on when
     encoding attachments for transport.
     """
-    # Gate the kotlin-receiver case on the duplicate-delivery bug.
-    # Note: pytest resolves fixtures before the test body runs, so this
-    # call does not skip fixture setup — it only short-circuits the
-    # assertions below. Loose-xfail pattern matching
-    # tests/wire/test_link_multihop.py.
-    _xfail_kotlin_receiver_multipacket_duplicate(lxmf_trio)
-
     sender, receiver = lxmf_transport_3peer
 
     content = f"direct file {secrets.token_hex(4)}"

--- a/tests/lxmf/test_direct.py
+++ b/tests/lxmf/test_direct.py
@@ -17,7 +17,6 @@ kotlin} for sender + receiver.
 import secrets
 
 
-
 # LXMF FIELD_FILE_ATTACHMENTS: key 5 per LXMF spec. Canonical wire shape
 # (see memory/lxmf-attachment-format-variance.md): list of 2-element
 # positional tuples, [[filename_str, data_bytes], ...]. This test


### PR DESCRIPTION
## Summary

Removes the `_xfail_kotlin_receiver_multipacket_duplicate` gate + its sole call site in `test_direct_with_file_attachment_multipacket`. The underlying double-delivery bug ([LXMF-kt#8](https://github.com/torlando-tech/LXMF-kt/issues/8)) was fixed by:

- [LXMF-kt#14](https://github.com/torlando-tech/LXMF-kt/pull/14) — dedup on `message.hash` instead of always-null `transientId`
- [LXMF-kt#16](https://github.com/torlando-tech/LXMF-kt/pull/16) — heterogeneous-key writes so propagation + paper paths also populate the dedup map

Both shipped in LXMF-kt v0.0.8. Requires reticulum-kt's conformance-bridge to bump its LXMF-kt pin from v0.0.4 → v0.0.8 (separate reticulum-kt PR) for the kotlin-receiver case to actually exercise the fix end-to-end. Until that lands, the kotlin-receiver variants would fail this test against the older pinned LXMF-kt; once both PRs land, the four parametrizations all pass.

Also drops the now-unused `import pytest` from `test_direct.py`.

Net diff: +5 / -33 lines.

—
_Posted by Claude (claude-opus-4-7) on behalf of @torlando-tech._