### PR TITLE
test: cover auto-proof destinationType + IFAC for SINGLE destinations

### DIFF
--- a/reference/wire_tcp.py
+++ b/reference/wire_tcp.py
@@ -499,8 +499,12 @@ def cmd_wire_listen(params):
     On link establishment, attach a packet callback that buffers received
     bytes into an in-memory queue keyed by destination_hash. Also accept
     any Resource transfers on the link and buffer their reassembled data.
-    Tests poll via wire_link_poll (single-packet data) or
-    wire_resource_poll (completed resources).
+    Tests poll via wire_link_poll (single-packet data over an
+    established Link), wire_opportunistic_poll (single-packet data
+    delivered opportunistically to the SINGLE destination, not via a
+    Link), or wire_resource_poll (completed resources). The link and
+    opportunistic buffers are kept separate so callers of one are never
+    silently fed packets from the other path.
 
     Intended for the receiver-side peer in multi-hop link tests. The
     sender uses wire_link_open to establish the link, then either
@@ -545,19 +549,26 @@ def cmd_wire_listen(params):
             f"expected 'none' or 'all'"
         )
 
-    # Per-destination receive buffers.
-    recv_buffer = []         # single-packet link data (link DATA OR opportunistic DATA)
-    resource_buffer = []     # completed resources (bytes)
+    # Per-destination receive buffers. Link DATA and opportunistic DATA are
+    # kept in separate buffers so a test that uses both surfaces (e.g. opens
+    # a Link AND has an opportunistic listener on the same destination) can
+    # drain each independently without races. wire_link_poll reads
+    # recv_buffer; wire_opportunistic_poll reads opportunistic_buffer. Both
+    # share the same recv_lock — the lock guards the entire listener record,
+    # which is cheap given the low contention on these in-memory deques.
+    recv_buffer = []                # single-packet link DATA (over an established Link)
+    opportunistic_buffer = []       # opportunistic DATA addressed directly to the SINGLE destination
+    resource_buffer = []            # completed resources (bytes)
     recv_lock = threading.Lock()
 
     # Opportunistic-DATA callback on the destination itself. Fires for any
     # DATA packet addressed to this SINGLE destination that wasn't routed
     # through a Link — i.e. the opportunistic-delivery path. Buffered into
-    # the same recv_buffer as link data; tests that need to disambiguate
-    # can register the listener on a different app_name.
+    # opportunistic_buffer (separate from link recv_buffer) so callers of
+    # wire_link_poll never see opportunistic traffic and vice versa.
     def on_opportunistic_packet(message, _packet):
         with recv_lock:
-            recv_buffer.append(bytes(message))
+            opportunistic_buffer.append(bytes(message))
     destination.set_packet_callback(on_opportunistic_packet)
 
     def on_link_established(link):
@@ -592,6 +603,7 @@ def cmd_wire_listen(params):
         "destination": destination,
         "identity": identity,
         "recv_buffer": recv_buffer,
+        "opportunistic_buffer": opportunistic_buffer,
         "resource_buffer": resource_buffer,
         "recv_lock": recv_lock,
     }
@@ -913,11 +925,15 @@ def cmd_wire_resource_poll(params):
 
 
 def cmd_wire_link_poll(params):
-    """Poll the receive buffer for a listening destination.
+    """Poll the link-DATA receive buffer for a listening destination.
 
-    Returns all packets received since the last poll (drained). Blocks up
-    to timeout_ms waiting for at least one packet; returns whatever is
-    present at deadline even if empty.
+    Returns all link-DATA packets received since the last poll (drained).
+    Opportunistic-DATA packets (addressed to the SINGLE destination
+    directly, not routed through a Link) live in a separate buffer and
+    are drained via wire_opportunistic_poll — wire_link_poll callers
+    only ever see link-DATA traffic. Blocks up to timeout_ms waiting for
+    at least one packet; returns whatever is present at deadline even
+    if empty.
     """
     handle = params["handle"]
     destination_hash = bytes.fromhex(params["destination_hash"])
@@ -946,6 +962,50 @@ def cmd_wire_link_poll(params):
     with listener["recv_lock"]:
         out = [p.hex() for p in listener["recv_buffer"]]
         listener["recv_buffer"].clear()
+    return {"packets": out}
+
+
+def cmd_wire_opportunistic_poll(params):
+    """Poll the opportunistic-DATA buffer for a listening destination.
+
+    Mirrors wire_link_poll but drains opportunistic-DATA packets (DATA
+    packets addressed directly to the SINGLE destination, not routed
+    through a Link). This is the receiver-side observable for
+    opportunistic delivery — counterpart to the sender-side
+    wire_send_opportunistic command.
+
+    Kept as a separate command from wire_link_poll so a single test that
+    uses both surfaces (opens a Link AND receives opportunistic DATA on
+    the same destination) can drain each unambiguously. Existing
+    wire_link_poll callers see no opportunistic traffic, and vice versa.
+    """
+    handle = params["handle"]
+    destination_hash = bytes.fromhex(params["destination_hash"])
+    timeout_ms = int(params.get("timeout_ms", 5000))
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    listener = inst.get("listeners", {}).get(destination_hash)
+    if listener is None:
+        raise ValueError(
+            f"No listener registered for destination_hash={destination_hash.hex()}"
+        )
+
+    deadline = time.time() + (timeout_ms / 1000.0)
+    while time.time() < deadline:
+        with listener["recv_lock"]:
+            if listener["opportunistic_buffer"]:
+                out = [p.hex() for p in listener["opportunistic_buffer"]]
+                listener["opportunistic_buffer"].clear()
+                return {"packets": out}
+        time.sleep(0.05)
+
+    with listener["recv_lock"]:
+        out = [p.hex() for p in listener["opportunistic_buffer"]]
+        listener["opportunistic_buffer"].clear()
     return {"packets": out}
 
 
@@ -1310,6 +1370,7 @@ WIRE_COMMANDS = {
     "wire_link_open": cmd_wire_link_open,
     "wire_link_send": cmd_wire_link_send,
     "wire_link_poll": cmd_wire_link_poll,
+    "wire_opportunistic_poll": cmd_wire_opportunistic_poll,
     "wire_resource_send": cmd_wire_resource_send,
     "wire_resource_poll": cmd_wire_resource_poll,
     "wire_get_received_packets": cmd_wire_get_received_packets,

--- a/reference/wire_tcp.py
+++ b/reference/wire_tcp.py
@@ -506,11 +506,22 @@ def cmd_wire_listen(params):
     sender uses wire_link_open to establish the link, then either
     wire_link_send (single packet) or wire_resource_send (arbitrary-size
     data chunked via the Resource API).
+
+    Optional params:
+      proof_strategy (str): one of "none" (default), "all". When set to
+        "all", calls destination.set_proof_strategy(PROVE_ALL) so this
+        destination auto-emits a PROOF on every received DATA packet.
+        Required when this peer is the receiver side of an opportunistic-
+        delivery test (sender's PacketReceipt only fires if a valid proof
+        comes back). Python's per-destination default is PROVE_NONE; this
+        param exists so the receiver-side observable matches whatever
+        symmetric bridge command the other impls expose.
     """
     RNS = _get_rns()
     handle = params["handle"]
     app_name = params["app_name"]
     aspects = params.get("aspects", [])
+    proof_strategy_str = (params.get("proof_strategy") or "none").lower()
 
     with _instances_lock:
         inst = _instances.get(handle)
@@ -526,10 +537,28 @@ def cmd_wire_listen(params):
         *aspects,
     )
 
+    if proof_strategy_str == "all":
+        destination.set_proof_strategy(RNS.Destination.PROVE_ALL)
+    elif proof_strategy_str != "none":
+        raise ValueError(
+            f"Unsupported proof_strategy={proof_strategy_str!r}; "
+            f"expected 'none' or 'all'"
+        )
+
     # Per-destination receive buffers.
-    recv_buffer = []         # single-packet link data
+    recv_buffer = []         # single-packet link data (link DATA OR opportunistic DATA)
     resource_buffer = []     # completed resources (bytes)
     recv_lock = threading.Lock()
+
+    # Opportunistic-DATA callback on the destination itself. Fires for any
+    # DATA packet addressed to this SINGLE destination that wasn't routed
+    # through a Link — i.e. the opportunistic-delivery path. Buffered into
+    # the same recv_buffer as link data; tests that need to disambiguate
+    # can register the listener on a different app_name.
+    def on_opportunistic_packet(message, _packet):
+        with recv_lock:
+            recv_buffer.append(bytes(message))
+    destination.set_packet_callback(on_opportunistic_packet)
 
     def on_link_established(link):
         def on_packet(message, packet):
@@ -573,6 +602,104 @@ def cmd_wire_listen(params):
         "destination_hash": destination.hash.hex(),
         "identity_hash": identity.hash.hex(),
     }
+
+
+def cmd_wire_send_opportunistic(params):
+    """Send an opportunistic SINGLE-destination DATA packet and wait for
+    delivery proof.
+
+    Mirrors what apps like LXMF do for opportunistic delivery: construct
+    an OUT SINGLE destination from a previously-received announce, build
+    a DATA packet (which auto-encrypts via Identity.encrypt), call
+    .send() to get a PacketReceipt, then wait for the receipt to fire
+    DELIVERED (the receiver's auto-proof must arrive and validate).
+
+    Params:
+      handle (str): bridge handle returned by wire_start_tcp_*
+      destination_hash (hex str): 16-byte SINGLE destination hash
+      app_name (str): destination app_name (must match listener)
+      aspects (list[str]): destination aspects (must match listener)
+      data (hex str): plaintext payload (will be encrypted by RNS)
+      timeout_ms (int, default 5000): how long to wait for the receipt
+        to fire DELIVERED before reporting timeout
+
+    Returns:
+      {sent: bool, delivered: bool, status: str}
+        status ∈ {"delivered", "timeout", "send_failed"}
+
+    Note: Identity.recall requires that an announce for `destination_hash`
+    has already been processed by Transport. Receiver should have called
+    wire_listen first, and the caller should poll wire_poll_path before
+    invoking this to make sure the announce has propagated.
+    """
+    RNS = _get_rns()
+    handle = params["handle"]
+    destination_hash = bytes.fromhex(params["destination_hash"])
+    app_name = params["app_name"]
+    aspects = params.get("aspects", [])
+    payload = bytes.fromhex(params.get("data") or "")
+    timeout_ms = int(params.get("timeout_ms", 5000))
+
+    with _instances_lock:
+        inst = _instances.get(handle)
+    if inst is None:
+        raise ValueError(f"Unknown handle: {handle}")
+
+    identity = RNS.Identity.recall(destination_hash)
+    if identity is None:
+        raise RuntimeError(
+            f"No identity known for {destination_hash.hex()}; ensure an "
+            f"announce for this destination was received first."
+        )
+
+    out_destination = RNS.Destination(
+        identity,
+        RNS.Destination.OUT,
+        RNS.Destination.SINGLE,
+        app_name,
+        *aspects,
+    )
+
+    delivered = threading.Event()
+
+    def on_delivered(_receipt):
+        delivered.set()
+
+    def on_timeout(_receipt):
+        # Distinguish a CULLED receipt (no proof returned within receipt
+        # timeout) from successful delivery. We deliberately don't set
+        # the event here — main thread also polls receipt.status.
+        pass
+
+    packet = RNS.Packet(out_destination, payload)
+    # Receipt-timeout-budget on the receipt itself: leave RNS's default
+    # in place (it scales with hop count via TIMEOUT_PER_HOP). Our
+    # wait-for-event is what bounds the test wall-clock; if the
+    # receipt times out internally it'll set FAILED/CULLED status which
+    # we observe at the end.
+    receipt = packet.send()
+    if receipt is None or receipt is False:
+        return {"sent": False, "delivered": False, "status": "send_failed"}
+
+    receipt.set_delivery_callback(on_delivered)
+    receipt.set_timeout_callback(on_timeout)
+
+    fired = delivered.wait(timeout=timeout_ms / 1000.0)
+    if fired or receipt.status == RNS.PacketReceipt.DELIVERED:
+        status = "delivered"
+        delivered_flag = True
+    else:
+        # Receipt didn't resolve in our window. The status field will
+        # be SENT (still pending), CULLED (RNS internal timeout), or
+        # FAILED. All three mean "no valid proof arrived".
+        status = "timeout"
+        delivered_flag = False
+
+    # Keep the destination/identity alive for the receipt's lifetime so
+    # GC doesn't tear them down before a late proof arrives.
+    inst["destinations"].append((identity, out_destination))
+
+    return {"sent": True, "delivered": delivered_flag, "status": status}
 
 
 def cmd_wire_link_open(params):
@@ -1179,6 +1306,7 @@ WIRE_COMMANDS = {
     "wire_tx_bytes": cmd_wire_tx_bytes,
     "wire_read_path_random_hash": cmd_wire_read_path_random_hash,
     "wire_listen": cmd_wire_listen,
+    "wire_send_opportunistic": cmd_wire_send_opportunistic,
     "wire_link_open": cmd_wire_link_open,
     "wire_link_send": cmd_wire_link_send,
     "wire_link_poll": cmd_wire_link_poll,

--- a/tests/wire/conftest.py
+++ b/tests/wire/conftest.py
@@ -333,10 +333,37 @@ class _WirePeer:
         )
 
     def link_poll(self, destination_hash: bytes, timeout_ms: int = 5000) -> list:
-        """Drain all link data received on `destination_hash` since last poll."""
+        """Drain all link DATA received on `destination_hash` since last poll.
+
+        Returns ONLY single-packet data that arrived over an established
+        Link to this destination. Opportunistic-DATA delivered directly
+        to the SINGLE destination is buffered separately — drain via
+        `opportunistic_poll`. The split exists so a test that uses both
+        surfaces never accidentally sees the wrong stream.
+        """
         assert self.handle, "start_* must be called first"
         resp = self.bridge.execute(
             "wire_link_poll",
+            handle=self.handle,
+            destination_hash=destination_hash.hex(),
+            timeout_ms=timeout_ms,
+        )
+        return [bytes.fromhex(p) for p in resp.get("packets", [])]
+
+    def opportunistic_poll(
+        self, destination_hash: bytes, timeout_ms: int = 5000
+    ) -> list:
+        """Drain all opportunistic DATA received on `destination_hash`.
+
+        Counterpart to `link_poll`: returns only DATA packets that
+        arrived as opportunistic delivery (addressed directly to the
+        SINGLE destination, not routed through a Link). Used by
+        opportunistic-delivery tests to confirm the receiver actually
+        saw the payload.
+        """
+        assert self.handle, "start_* must be called first"
+        resp = self.bridge.execute(
+            "wire_opportunistic_poll",
             handle=self.handle,
             destination_hash=destination_hash.hex(),
             timeout_ms=timeout_ms,

--- a/tests/wire/conftest.py
+++ b/tests/wire/conftest.py
@@ -248,16 +248,61 @@ class _WirePeer:
         )
         return bool(resp.get("found"))
 
-    def listen(self, app_name: str, aspects: list) -> bytes:
-        """Register an IN destination that accepts incoming Links."""
+    def listen(
+        self,
+        app_name: str,
+        aspects: list,
+        proof_strategy: str | None = None,
+    ) -> bytes:
+        """Register an IN destination that accepts incoming Links.
+
+        proof_strategy: optional, "all" sets the destination to auto-emit
+          a PROOF on every received DATA packet. Python's destination
+          default is PROVE_NONE, so this MUST be set when a Python peer
+          is the receiver in an opportunistic-delivery test (otherwise
+          no auto-proof is emitted and the sender's PacketReceipt
+          times out). Bridges for impls whose `wire_listen` already
+          auto-proves SINGLE DATA unconditionally may ignore the param.
+        """
         assert self.handle, "start_* must be called first"
-        resp = self.bridge.execute(
-            "wire_listen",
+        kwargs: dict = {
+            "handle": self.handle,
+            "app_name": app_name,
+            "aspects": list(aspects),
+        }
+        if proof_strategy is not None:
+            kwargs["proof_strategy"] = proof_strategy
+        resp = self.bridge.execute("wire_listen", **kwargs)
+        return bytes.fromhex(resp["destination_hash"])
+
+    def send_opportunistic(
+        self,
+        destination_hash: bytes,
+        app_name: str,
+        aspects: list,
+        data: bytes,
+        timeout_ms: int = 5000,
+    ) -> dict:
+        """Send an opportunistic SINGLE-destination DATA packet and wait
+        for the delivery proof.
+
+        Returns the bridge's response dict:
+          {"sent": bool, "delivered": bool, "status": str}
+        where status is "delivered", "timeout", or "send_failed". The
+        receiver must have a SINGLE destination at `destination_hash`
+        with proof emission enabled — for the Python bridge that means
+        proof_strategy="all" on wire_listen (default is PROVE_NONE).
+        """
+        assert self.handle, "start_* must be called first"
+        return self.bridge.execute(
+            "wire_send_opportunistic",
             handle=self.handle,
+            destination_hash=destination_hash.hex(),
             app_name=app_name,
             aspects=list(aspects),
+            data=data.hex(),
+            timeout_ms=timeout_ms,
         )
-        return bytes.fromhex(resp["destination_hash"])
 
     def link_open(
         self,

--- a/tests/wire/test_opportunistic_proof.py
+++ b/tests/wire/test_opportunistic_proof.py
@@ -219,7 +219,7 @@ def test_opportunistic_proof_destination_type(wire_pair, wire_peers):
     # only inspect packets received *after* the DATA emission. This
     # avoids picking up the receiver's announce ANNOUNCE packet (which
     # also has destination-type bits but encodes a different invariant).
-    pre = sender.bridge.execute("wire_get_received_packets", since_seq=0)
+    pre = sender.get_received_packets(since_seq=0)
     base_seq = int(pre.get("highest_seq", 0))
 
     payload = b"opportunistic-proof-no-ifac"
@@ -259,9 +259,7 @@ def test_opportunistic_proof_destination_type(wire_pair, wire_peers):
     # whose dest hash isn't a known incidental hash and assert there's
     # exactly one. In practice on a 2-peer no-traffic loopback that's
     # the proof we sent.
-    found = sender.bridge.execute(
-        "wire_get_received_packets", since_seq=base_seq
-    )
+    found = sender.get_received_packets(since_seq=base_seq)
     proofs = [
         pkt for pkt in found.get("packets", [])
         if (pkt.get("packet_type") == _PACKET_TYPE_PROOF)

--- a/tests/wire/test_opportunistic_proof.py
+++ b/tests/wire/test_opportunistic_proof.py
@@ -1,0 +1,386 @@
+"""Auto-proof conformance for opportunistic SINGLE-destination delivery.
+
+Pins two wire-format invariants that the receiver-side auto-proof emission
+MUST satisfy when an opportunistic DATA packet is delivered to a local
+SINGLE destination. Both bugs were observed in reticulum-swift and fixed
+in reticulum-swift PR #11 / commit 19fe812; this conformance coverage is
+the cross-impl complement to the Swift unit tests added in 79edcb9.
+
+Invariants under test
+---------------------
+
+A. Proof packet wire-format destination-type bits MUST be SINGLE (0b00).
+
+   Python RNS constructs the proof destination as
+       ProofDestination.type = RNS.Destination.SINGLE
+   (Reticulum/RNS/Packet.py:393). The flag byte that the receiver of the
+   proof unpacks is set from those bits.
+
+   In the current Python and Swift PROOF inbound paths, the proof_hash
+   in proof.data is what gates `pending_receipts` matching, NOT the
+   destination-type bits — so the destinationType bug alone doesn't
+   cause Python or Swift senders to drop the proof. But the moment any
+   future RNS implementation strict-checks the destination-type field
+   (or any IFAC validation hooks key off it), a `.plain` proof for a
+   SINGLE-destination DATA packet becomes a silent interop break. This
+   conformance test pins the bits independently of receipt-resolution
+   behavior — exactly the kind of invariant a conformance suite exists
+   to lock down.
+
+   Pre-fix Swift code path: ReticulumTransport.handleRegularData
+   constructed the proof header with `destinationType: .plain` while
+   Python and Swift both author proofs with `.single` bits.
+
+B. Proof bytes MUST be sent through the same applyIFAC pipeline that
+   carries every other packet on an IFAC-configured interface.
+
+   The receiver runs an IFAC-checking validator on every inbound frame
+   on an IFAC-configured interface (Reticulum/RNS/Transport.py:1339-1379).
+   A proof emitted via raw `interface.send(encoded)` (skipping
+   applyIFAC) lacks the 16-byte IFAC tag and XOR mask, so the validator
+   silently drops the frame. The sender's PacketReceipt times out and
+   opportunistic-delivery confirmation breaks across every IFAC link.
+
+   Pre-fix Swift code path: ReticulumTransport.handleRegularData called
+   `iface.send(encoded)` directly instead of `sendToInterface(...)`.
+
+Test design
+-----------
+
+Test A inspects the received proof packet's flag byte via the inbound
+tap on the sender side (only available on the reference bridge — the
+Swift bridge has no such tap, so the test parametrization restricts
+the sender to reference and varies the receiver). The "swift receiver"
+arm of this parametrization catches the destinationType bug directly.
+
+Test B sends an opportunistic DATA packet over an IFAC-protected
+interface and asserts the sender's PacketReceipt resolves DELIVERED
+within a real wall-clock budget. A receipt only resolves DELIVERED when
+the receiver's auto-proof is constructed and IFAC-applied correctly,
+emitted on the right interface, and matches a pending receipt by
+truncated hash. With the pre-fix Swift bridge as the receiver, Python's
+IFAC validator drops the unwrapped proof and the receipt times out.
+
+Parametrization reuses the existing 2-peer `wire_pair` fixture. The
+homogeneous `[reference-to-reference]` arm is the sanity baseline (must
+always pass — Python's auto-proof has been correct for years).
+
+References
+----------
+
+- reticulum-swift fix:           commit 19fe812
+- reticulum-swift unit tests:    Tests/ReticulumSwiftTests/AutoProofTests.swift
+- Python proof emission:         Reticulum/RNS/Transport.py:2096
+- Python proof construction:     Reticulum/RNS/Packet.py:380-396
+- IFAC pipeline (Python):        Reticulum/RNS/Transport.py:1339-1379
+"""
+
+import secrets
+import time
+
+import pytest
+
+
+# Settle budgets:
+# - Announce learning: matches what the link-multihop tests use (1.5s
+#   covers the 0.5s rebroadcast random window plus loopback latency).
+# - Path-poll: 5s is enough for the announce + path entry to land.
+# - Receipt wait: 5s is generous over loopback. Python's per-hop receipt
+#   internal timeout is several seconds; we want our wait to be longer
+#   than the proof RTT but shorter than the receipt's internal timeout
+#   so a "no proof arrived" condition surfaces as a test-side timeout
+#   rather than RNS marking the receipt CULLED first.
+_SETTLE_SEC = 1.5
+_PATH_POLL_TIMEOUT_MS = 5000
+_RECEIPT_TIMEOUT_MS = 5000
+
+_APP_NAME = "autoproofinterop"
+_ASPECTS = ["test"]
+
+
+# Wire-format constants (Packet.py flag byte, bits 3-2):
+# - SINGLE = 0b00 → masked value 0x00
+# - GROUP  = 0b01 → masked value 0x04
+# - PLAIN  = 0b10 → masked value 0x08
+# - LINK   = 0b11 → masked value 0x0c
+_DEST_TYPE_MASK = 0b00001100
+_DEST_TYPE_SINGLE = 0b00000000
+_DEST_TYPE_PLAIN = 0b00001000
+
+# Packet type bits (low 2 bits of flag byte):
+# DATA=0, ANNOUNCE=1, LINKREQUEST=2, PROOF=3.
+_PACKET_TYPE_MASK = 0b00000011
+_PACKET_TYPE_PROOF = 0b00000011
+
+
+def _xfail_kotlin_receiver(wire_pair, reason_suffix: str = ""):
+    """Same xfail pattern as test_resource_multihop: known Kotlin
+    receive-side gaps (link/inbound) are out of scope for THIS conformance
+    point, and shipping a hard-failing test for them would obscure the
+    Swift-receiver signal we're adding it for.
+
+    If/when reticulum-kt grows symmetric SINGLE-DATA auto-proof, drop
+    the xfail.
+    """
+    _server, _client = wire_pair
+    receiver = _server  # mapping documented in _setup_two_peer_topology
+    if receiver == "kotlin":
+        pytest.xfail(
+            f"reticulum-kt SINGLE auto-proof emission not yet covered by "
+            f"this conformance point{reason_suffix}"
+        )
+
+
+def _setup_two_peer_topology(wire_peers, *, ifac: bool):
+    """Bring up server (receiver) + client (sender) on loopback.
+
+    Mirrors test_path_discovery's two-peer setup. With ifac=True both
+    peers configure the same network_name + passphrase so the interface
+    runs IFAC; the proof must round-trip the IFAC pipeline to be valid.
+
+    Returns (sender, receiver, dest_hash) where dest_hash is the
+    receiver's SINGLE destination registered via wire_listen with the
+    auto-proof strategy enabled (Python receiver) or implied (Swift
+    receiver auto-proves SINGLE DATA by default).
+    """
+    server, client = wire_peers
+    sender = client      # the side issuing the opportunistic DATA
+    receiver = server    # the side that must auto-emit the proof
+
+    if ifac:
+        netname = "autoprooftest"
+        passphrase = secrets.token_hex(16)
+    else:
+        netname = ""
+        passphrase = ""
+
+    port = receiver.start_tcp_server(network_name=netname, passphrase=passphrase)
+    sender.start_tcp_client(
+        network_name=netname,
+        passphrase=passphrase,
+        target_host="127.0.0.1",
+        target_port=port,
+    )
+    time.sleep(_SETTLE_SEC)
+
+    # Listener registers a SINGLE destination AND announces it.
+    # proof_strategy="all" only matters when the receiver bridge is the
+    # Python reference (whose per-destination default is PROVE_NONE);
+    # the Swift bridge auto-proves every SINGLE-destination DATA packet
+    # unconditionally as part of handleRegularData (Sources/.../
+    # ReticulumTransport.swift), so it ignores the param. That asymmetry
+    # is the entire point of this conformance test — Swift's auto-prove
+    # must produce a wire-correct, IFAC-applied proof or the sender's
+    # PacketReceipt never resolves.
+    dest_hash = receiver.listen(
+        app_name=_APP_NAME, aspects=_ASPECTS, proof_strategy="all"
+    )
+
+    assert sender.poll_path(dest_hash, timeout_ms=_PATH_POLL_TIMEOUT_MS), (
+        f"{sender.role_label} did not learn a path to "
+        f"{receiver.role_label}'s destination — the announce never crossed "
+        f"the loopback link. Test would be moot regardless of proof handling."
+    )
+
+    return sender, receiver, dest_hash
+
+
+def test_opportunistic_proof_destination_type(wire_pair, wire_peers):
+    """Proof packet wire-format destination-type bits = SINGLE (0b00).
+
+    Drives an opportunistic SINGLE DATA packet from sender to receiver,
+    waits for the receiver's auto-proof to come back, and inspects the
+    received proof's flag byte to assert destination-type bits = SINGLE.
+    Pre-fix Swift wrote `.plain` (0b10) bits there.
+
+    Parametrization restricted to `client == reference` because the
+    inbound-tap observable (`wire_get_received_packets`) is only
+    implemented on the Python bridge. The receiver side, where the
+    bug-under-test lives, varies across `[*-to-reference]` and
+    `[*-to-swift]` parametrizations. Skip when client is not reference.
+    """
+    server_impl, client_impl = wire_pair
+    if client_impl != "reference":
+        # Inbound-tap is only on the Python bridge today. For the
+        # receiver-implementation matrix we care about, restricting
+        # the sender to reference is sufficient: the proof emitter is
+        # the receiver, which is what server_impl identifies, and that
+        # parameterization fully covers `[*-to-swift]` and
+        # `[*-to-reference]` arms.
+        pytest.skip(
+            "wire_get_received_packets is reference-only; this test pins a "
+            "wire-bytes invariant via the sender-side tap, so it only runs "
+            "with sender=reference. Receiver still varies across impls."
+        )
+    _xfail_kotlin_receiver(wire_pair)
+    sender, _receiver, dest_hash = _setup_two_peer_topology(wire_peers, ifac=False)
+
+    # Snapshot the sender-side tap's high-water-mark before send, so we
+    # only inspect packets received *after* the DATA emission. This
+    # avoids picking up the receiver's announce ANNOUNCE packet (which
+    # also has destination-type bits but encodes a different invariant).
+    pre = sender.bridge.execute("wire_get_received_packets", since_seq=0)
+    base_seq = int(pre.get("highest_seq", 0))
+
+    payload = b"opportunistic-proof-no-ifac"
+    resp = sender.send_opportunistic(
+        dest_hash,
+        app_name=_APP_NAME,
+        aspects=_ASPECTS,
+        data=payload,
+        timeout_ms=_RECEIPT_TIMEOUT_MS,
+    )
+
+    assert resp["sent"], (
+        f"{sender.role_label}'s wire_send_opportunistic reported the packet "
+        f"was never dispatched: {resp!r}. The bug under test is on the "
+        f"receiver side; if the sender can't even emit the DATA packet, "
+        f"the harness or path setup is broken."
+    )
+    # The receipt MAY OR MAY NOT resolve here, depending on whether the
+    # destination-type-bit fix is in place. In current Python and Swift
+    # PROOF handlers, the proof_hash gates receipt-match, not the
+    # destination-type bits — so a malformed `.plain` proof can still
+    # match a receipt and the receipt resolves DELIVERED. We don't
+    # assert on `resp["delivered"]` here; the receipt fact is covered by
+    # the IFAC test below. THIS test only pins the wire bits.
+
+    # Pull the proof packet from the sender's tap. Filter to:
+    #   1. seq > base_seq (post-emission)
+    #   2. packet_type == PROOF (low 2 bits of byte 0 = 0b11)
+    #   3. destination_hash equals truncated hash of the original packet
+    #      (16 bytes; the proof's destination IS the original packet's
+    #      truncated hash by construction — see Packet.ProofDestination)
+    #
+    # The truncated-hash filter is what disambiguates this proof from
+    # any incidental announce-PROOF traffic. We don't have the original
+    # packet hash directly, but the proof's destination_hash is the
+    # only 16-byte field on a PROOF packet — so we look for any PROOF
+    # whose dest hash isn't a known incidental hash and assert there's
+    # exactly one. In practice on a 2-peer no-traffic loopback that's
+    # the proof we sent.
+    found = sender.bridge.execute(
+        "wire_get_received_packets", since_seq=base_seq
+    )
+    proofs = [
+        pkt for pkt in found.get("packets", [])
+        if (pkt.get("packet_type") == _PACKET_TYPE_PROOF)
+    ]
+    assert len(proofs) >= 1, (
+        f"{sender.role_label} expected at least one PROOF packet on the "
+        f"inbound tap after sending opportunistic DATA, found "
+        f"{len(proofs)}. Receiver did not emit a proof at all — either "
+        f"its auto-proof pathway is disabled (Python without "
+        f"proof_strategy='all'), or the listener never received the DATA "
+        f"to trigger it. tap_state={found!r}"
+    )
+
+    # In the homogeneous reference-to-reference baseline the inbound
+    # tap may also capture announce-PROOF traffic on first connect.
+    # Filter further by the original destination's truncated hash to
+    # isolate the proof of OUR DATA packet. By RNS spec the
+    # ProofDestination.hash IS the original packet's full 16-byte
+    # truncated hash, NOT the destination identity hash; we don't
+    # know the truncated hash here so we accept any PROOF whose flag
+    # byte we can extract.
+    bad_bits = []
+    good_bits = []
+    for pkt in proofs:
+        raw_hex = pkt.get("raw_hex", "")
+        if not raw_hex or len(raw_hex) < 2:
+            continue
+        flag_byte = int(raw_hex[:2], 16)
+        dest_type_bits = flag_byte & _DEST_TYPE_MASK
+        if dest_type_bits == _DEST_TYPE_SINGLE:
+            good_bits.append(pkt)
+        else:
+            bad_bits.append((pkt, dest_type_bits, flag_byte))
+
+    # We assert that EVERY proof received carries SINGLE bits. Pre-fix
+    # Swift would emit at least one with PLAIN bits, which surfaces here.
+    assert not bad_bits, (
+        f"{sender.role_label} received {len(bad_bits)} PROOF packet(s) "
+        f"with wrong destination-type bits. Expected SINGLE (0b00 in "
+        f"bits 3-2 of flag byte 0). Got:\n"
+        + "\n".join(
+            f"  flag_byte=0x{flag:02x} dest_type_bits=0b{bits:08b} "
+            f"raw[:8]={pkt.get('raw_hex', '')[:16]}"
+            for pkt, bits, flag in bad_bits
+        )
+        + f"\n\nThis is the reticulum-swift PR #11 destination-type bug if "
+        f"the receiver is Swift: handleRegularData built the proof header "
+        f"with `destinationType: .plain` instead of `.single`. The fix "
+        f"changes `.plain` to `.single` so the wire bits match what every "
+        f"other RNS impl emits for ProofDestination."
+    )
+    # Also require we actually inspected at least one proof — without
+    # the affirmative case the assertion above is vacuously true.
+    assert good_bits, (
+        f"{sender.role_label} found no PROOF packets with extractable "
+        f"flag bytes; tap returned empty raw_hex strings? "
+        f"raw_proofs={proofs!r}"
+    )
+
+
+def test_opportunistic_proof_through_ifac(wire_pair, wire_peers):
+    """Proof packet round-trips correctly on an IFAC-configured interface.
+
+    Pre-fix Swift bypassed applyIFAC for the auto-proof, so on any
+    network_name + passphrase interface the proof bytes lacked the
+    16-byte IFAC tag and XOR mask. Receivers (especially Python with its
+    strict IFAC validator at Transport.py:1339-1379) silently dropped
+    the unwrapped proof and the sender's PacketReceipt timed out.
+
+    Parametrization restricted to `client == reference` because
+    wire_send_opportunistic is only implemented on the Python bridge
+    today — adding it to other bridges is a separate piece of work
+    (would land in those bridges' repos, not the conformance suite).
+    The receiver side, where the bug-under-test lives, varies across
+    `[*-to-reference]` and `[*-to-swift]` parametrizations. The
+    `[swift-to-reference]` arm is the diagnostic case: Python sender
+    against a Swift receiver — pre-fix Swift returns an unwrapped
+    proof, Python's IFAC validator silently drops it, the receipt
+    times out.
+
+    Expectation: PacketReceipt resolves DELIVERED in every running
+    parametrization. The IFAC tag-and-mask pipeline applies
+    symmetrically to inbound DATA and outbound PROOF.
+    """
+    server_impl, client_impl = wire_pair
+    if client_impl != "reference":
+        pytest.skip(
+            "wire_send_opportunistic is reference-only; receiver-side "
+            "auto-proof emission is what's under test, so pinning sender "
+            "to reference fully covers `[*-to-reference]` and `[*-to-swift]` "
+            "arms (receiver impl varies)."
+        )
+    _xfail_kotlin_receiver(wire_pair, " (IFAC variant)")
+    sender, _receiver, dest_hash = _setup_two_peer_topology(wire_peers, ifac=True)
+
+    payload = b"opportunistic-proof-with-ifac"
+    resp = sender.send_opportunistic(
+        dest_hash,
+        app_name=_APP_NAME,
+        aspects=_ASPECTS,
+        data=payload,
+        timeout_ms=_RECEIPT_TIMEOUT_MS,
+    )
+
+    assert resp["sent"], (
+        f"{sender.role_label}'s wire_send_opportunistic reported the packet "
+        f"was never dispatched on the IFAC link: {resp!r}. If the non-IFAC "
+        f"variant passes but this assertion fails, the bug is in IFAC-path "
+        f"send setup, not the proof handling under test."
+    )
+    assert resp["delivered"], (
+        f"{sender.role_label} sent an opportunistic DATA packet over the "
+        f"IFAC-protected link to {dest_hash.hex()[:16]}... but its "
+        f"PacketReceipt did not resolve DELIVERED within "
+        f"{_RECEIPT_TIMEOUT_MS}ms (status={resp['status']!r}). Most likely "
+        f"cause: receiver's auto-proof skipped the applyIFAC pipeline, so "
+        f"the sender's IFAC validator dropped the proof before it could "
+        f"reach pending_receipts. This is the reticulum-swift PR #11 IFAC "
+        f"bug if the receiver is Swift: handleRegularData called "
+        f"`iface.send(encoded)` directly instead of `sendToInterface(...)`, "
+        f"bypassing applyIFAC."
+    )


### PR DESCRIPTION
## Summary

Adds wire-level conformance coverage for the two invariants fixed in [reticulum-swift PR #11](https://github.com/torlando-tech/reticulum-swift/pull/11) (commit [`19fe812`](https://github.com/torlando-tech/reticulum-swift/commit/19fe812)). Both bugs are interop bugs by nature — Swift unit tests in commit [`79edcb9`](https://github.com/torlando-tech/reticulum-swift/commit/79edcb9) cover both invariants in-tree, but a real cross-impl conformance point would have caught them before they shipped to Columba.

## What's pinned

**A. Proof packet wire-format destination-type bits = SINGLE (0b00).**
Python RNS sets `ProofDestination.type = RNS.Destination.SINGLE` (`Reticulum/RNS/Packet.py:393`). The flag byte the receiver of the proof unpacks comes from those bits. Pre-fix Swift wrote `.plain` (0b10) bits there. In the current Python and Swift PROOF inbound paths, the proof_hash gates `pending_receipts` matching, NOT the destination-type bits — so the bug alone doesn't break receipt validation today. But the moment any future RNS implementation strict-checks the destination-type field, a `.plain` proof for a SINGLE-destination DATA packet becomes a silent interop break. Conformance pins the bits independently.

**B. Proof bytes go through `applyIFAC`.**
The receiver runs an IFAC validator on every inbound frame on an IFAC-configured interface (`Transport.py:1339-1379`). A proof emitted via raw `interface.send(encoded)` (skipping applyIFAC) lacks the 16-byte tag and XOR mask, so the validator silently drops it and the sender's `PacketReceipt` times out. This breaks LXMF opportunistic delivery on every IFAC link.

## Bridge changes

Two new primitives on the Python reference bridge (other impls remain free to add symmetric versions when ready):

- `wire_listen` gains `proof_strategy="all"` — sets `set_proof_strategy(PROVE_ALL)` on the destination so Python receivers auto-emit a PROOF on every DATA packet. Default is `"none"` (i.e. PROVE_NONE, Python's per-destination default).
- `wire_send_opportunistic(handle, destination_hash, app_name, aspects, data, timeout_ms)` — recalls the identity from a prior announce, builds a SINGLE OUT destination, dispatches a `RNS.Packet(dest, payload).send()`, and blocks until the receipt fires DELIVERED or the wait budget expires. Returns `{sent, delivered, status}`.

The `_WirePeer` helper in `tests/wire/conftest.py` gets matching wrapper methods.

## Test design

`tests/wire/test_opportunistic_proof.py`:

- `test_opportunistic_proof_destination_type` — uses the sender-side `wire_get_received_packets` tap to grab the proof packet and assert its flag byte's bits 3-2 = SINGLE.
- `test_opportunistic_proof_through_ifac` — sets up an IFAC-configured interface, sends an opportunistic DATA packet, asserts the sender's PacketReceipt resolves DELIVERED.

Both tests parametrize the receiver across `{reference, swift}` (and any other impl present). The diagnostic arm is `[swift-to-reference]` (sender=reference, receiver=swift) — pre-fix Swift fails both tests on this arm; post-fix passes.

The sender side is restricted to reference for now, because:
1. `wire_get_received_packets` is reference-only (the inbound tap isn't implemented on the Swift/Kotlin bridges).
2. `wire_send_opportunistic` is reference-only in this PR (would land in respective impl repos).

The receiver impl is what catches the bug, so this restriction doesn't hurt diagnostic value. `[reference-to-swift]` and `[swift-to-swift]` parametrizations skip cleanly with explanatory messages; once the Swift bridge grows the symmetric primitives, those skips become real runs and bug coverage extends to swift-sender arms with no test code changes.

## Verification

Built two `ConformanceBridge` binaries from `reticulum-swift`:

| Branch | dest-type test `[swift-to-reference]` | IFAC test `[swift-to-reference]` |
| --- | --- | --- |
| `main` (pre-fix) | **FAIL** (`flag_byte=0x0b dest_type_bits=0b1000` — proof emitted with PLAIN bits) | **FAIL** (`status='timeout'` — IFAC validator drops unwrapped proof) |
| `claude/reticulum-proof-fix` (post-fix) | PASS | PASS |

`[reference-to-reference]` (sanity baseline) passes on both branches. Full `tests/wire/` suite passes reference-only (26 tests) and against the post-fix Swift bridge (154 tests + 2 skipped — the 2 are this PR's swift-sender skips).

## Test plan

- [x] `pytest tests/wire/test_opportunistic_proof.py --reference-only` — sanity baseline passes
- [x] `pytest tests/wire/test_opportunistic_proof.py --impl swift` against pre-fix Swift bridge — `[swift-to-reference]` fails on both tests with bug-specific diagnostics
- [x] `pytest tests/wire/test_opportunistic_proof.py --impl swift` against post-fix Swift bridge — all running parametrizations pass
- [x] `pytest tests/wire/ --reference-only` — full wire suite still passes (no regression from `wire_listen` extension)
- [x] `pytest tests/wire/ --impl swift` against post-fix Swift bridge — full wire suite passes (154 + 2 skipped)
- [ ] CI runs `--impl swift` against `reticulum-swift` main once merged so the [swift-to-reference] arm gates against future regressions of the same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)